### PR TITLE
Enable Indic and Indian numerals for the activity

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -32,6 +32,8 @@ from toolbars import TrigonometryToolbar
 from toolbars import BooleanToolbar
 from toolbars import MiscToolbar
 
+import numParser
+
 try:
     from sugar3.graphics.toolbarbox import ToolbarButton, ToolbarBox
     from sugar3.activity.widgets import ActivityToolbarButton
@@ -84,29 +86,20 @@ class CalcLayout:
             [4, 0, 2, 1, u'\u232B', self.col_gray3,
                 lambda w: self._parent.remove_character(-1)],
 
-            [0, 1, 1, 2, '7', self.col_gray2,
-                lambda w: self._parent.add_text('7')],
-            [1, 1, 1, 2, '8', self.col_gray2,
-                lambda w: self._parent.add_text('8')],
-            [2, 1, 1, 2, '9', self.col_gray2,
-                lambda w: self._parent.add_text('9')],
+            [0, 1, 1, 2, numParser.local('7'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('7'))],
+            [1, 1, 1, 2, numParser.local('8'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('8'))],
+            [2, 1, 1, 2, numParser.local('9'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('9'))],
 
-            [0, 3, 1, 2, '4', self.col_gray2,
-                lambda w: self._parent.add_text('4')],
-            [1, 3, 1, 2, '5', self.col_gray2,
-                lambda w: self._parent.add_text('5')],
-            [2, 3, 1, 2, '6', self.col_gray2,
-                lambda w: self._parent.add_text('6')],
+            [0, 3, 1, 2, numParser.local('4'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('4'))],
+            [1, 3, 1, 2, numParser.local('5'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('5'))],
+            [2, 3, 1, 2, numParser.local('6'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('6'))],
 
-            [0, 5, 1, 2, '1', self.col_gray2,
-                lambda w: self._parent.add_text('1')],
-            [1, 5, 1, 2, '2', self.col_gray2,
-                lambda w: self._parent.add_text('2')],
-            [2, 5, 1, 2, '3', self.col_gray2,
-                lambda w: self._parent.add_text('3')],
+            [0, 5, 1, 2, numParser.local('1'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('1'))],
+            [1, 5, 1, 2, numParser.local('2'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('2'))],
+            [2, 5, 1, 2, numParser.local('3'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('3'))],
 
-            [0, 7, 2, 2, '0', self.col_gray2,
-                lambda w: self._parent.add_text('0')],
+            [0, 7, 2, 2, numParser.local('0'), self.col_gray2, lambda w: self._parent.add_text(numParser.local('0'))],
+
             [2, 7, 1, 2, '.', self.col_gray2,
                 lambda w: self._parent.add_text('.')],
 

--- a/numParser.py
+++ b/numParser.py
@@ -1,0 +1,46 @@
+# -*- coding: UTF-8 -*-
+import os
+
+locale = os.getenv('LANG', u'en_US.utf8')
+
+# Define local dicts
+arabic = {u'0': u'0', u'1': u'1', u'2': u'2', u'3': u'3', u'4': u'4', u'5': u'5', u'6': u'6', u'7': u'7', u'8': u'8', u'9': u'9'}
+indic = {u'۰': u'0', u'۱': u'1', u'۲': u'2', u'۳': u'3', u'۴': u'4', u'۵': u'5', u'۶': u'6', u'۷': u'7', u'۸': u'8', u'۹': u'9'}
+tamil = {u'௦': u'0', u'௧': u'1', u'௨': u'2', u'௩': u'3', u'௪': u'4', u'௫': u'5', u'௬': u'6', u'௭': u'7', u'௮': u'8', u'௯': u'9'}
+devanagari = {u'०': u'0', u'१': u'1', u'२': u'2', u'३': u'3', u'४': u'4', u'५': u'5', u'६': u'6', u'७': u'7', u'८': u'8', u'९': u'9'}
+kannada = {u'0': u'0', u'౧': u'1', u'౨': u'2', u'౩': u'3', u'౪': u'4', u'౫': u'5', u'౬': u'6', u'౭': u'7', u'౮': u'8', u'౯': u'9'}
+malayam = {u'൦': u'0', u'൧': u'1', u'൨': u'2', u'൩': u'3', u'൪': u'4', u'൫': u'5', u'൬': u'6', u'൬': u'7', u'൮': u'8', u'൯': u'9'}
+
+if locale in ['ar_SA.utf8', 'ar_YE.utf8', 'ar_AE.utf8', 'ar_SY.utf8', 'ar_OM.utf8', 'ar_JO.utf8', 'ar_IQ.utf8', 'ar_KW.utf8', 'ar_LB.utf8', 'ar_IQ.utf8', 'ar_SD.utf8', 'ar_EG.utf8', 'fa_IR.utf8']:
+    localDic = indic
+elif locale[0:3] in {'ta_'}:
+    localDic = tamil
+elif locale[0:3] in {'hi_', 'bn_', 'gu_', 'mr_'}:
+    localDic = devanagari
+elif locale[0:3] in {'kn_'}:
+    localDic = kannada
+elif locale[0:3] in {'ml_'}:
+    localDic = malayam
+else:
+    localDic = arabic
+
+standardDic = {v:k for k, v in localDic.items()}
+
+def local(standardString):
+    result = u''
+    for c in standardString:
+        if c.encode('utf-8') in standardDic:
+            result =  result + standardDic[c]
+        else:
+            result = result + c
+    return result
+
+def standard(localString):
+    localString = localString.decode('utf-8')
+    result = u''
+    for c in localString:
+        if c in localDic:
+            result = result + localDic[c]
+        else:
+            result = result + c
+    return result

--- a/numParser.py
+++ b/numParser.py
@@ -5,10 +5,10 @@ locale = os.getenv('LANG', u'en_US.utf8')
 
 # Define local dicts
 arabic = {u'0': u'0', u'1': u'1', u'2': u'2', u'3': u'3', u'4': u'4', u'5': u'5', u'6': u'6', u'7': u'7', u'8': u'8', u'9': u'9'}
-indic = {u'۰': u'0', u'۱': u'1', u'۲': u'2', u'۳': u'3', u'۴': u'4', u'۵': u'5', u'۶': u'6', u'۷': u'7', u'۸': u'8', u'۹': u'9'}
+indic = {u'۰': u'0', u'۱': u'1', u'٢': u'2', u'٣': u'3', u'۴': u'4', u'۵': u'5', u'۶': u'6', u'۷': u'7', u'۸': u'8', u'۹': u'9'}
 tamil = {u'௦': u'0', u'௧': u'1', u'௨': u'2', u'௩': u'3', u'௪': u'4', u'௫': u'5', u'௬': u'6', u'௭': u'7', u'௮': u'8', u'௯': u'9'}
 devanagari = {u'०': u'0', u'१': u'1', u'२': u'2', u'३': u'3', u'४': u'4', u'५': u'5', u'६': u'6', u'७': u'7', u'८': u'8', u'९': u'9'}
-kannada = {u'0': u'0', u'౧': u'1', u'౨': u'2', u'౩': u'3', u'౪': u'4', u'౫': u'5', u'౬': u'6', u'౭': u'7', u'౮': u'8', u'౯': u'9'}
+kannada = {u'೦': u'0', u'౧': u'1', u'೨': u'2', u'೩': u'3', u'౪': u'4', u'೫': u'5', u'೬': u'6', u'೭': u'7', u'౮': u'8', u'౯': u'9'}
 malayam = {u'൦': u'0', u'൧': u'1', u'൨': u'2', u'൩': u'3', u'൪': u'4', u'൫': u'5', u'൬': u'6', u'൭': u'7', u'൮': u'8', u'൯': u'9'}
 
 if locale in ['ar_SA.utf8', 'ar_YE.utf8', 'ar_AE.utf8', 'ar_SY.utf8', 'ar_OM.utf8', 'ar_JO.utf8', 'ar_IQ.utf8', 'ar_KW.utf8', 'ar_LB.utf8', 'ar_IQ.utf8', 'ar_SD.utf8', 'ar_EG.utf8', 'fa_IR.utf8']:

--- a/numParser.py
+++ b/numParser.py
@@ -9,7 +9,7 @@ indic = {u'۰': u'0', u'۱': u'1', u'۲': u'2', u'۳': u'3', u'۴': u'4', u'۵':
 tamil = {u'௦': u'0', u'௧': u'1', u'௨': u'2', u'௩': u'3', u'௪': u'4', u'௫': u'5', u'௬': u'6', u'௭': u'7', u'௮': u'8', u'௯': u'9'}
 devanagari = {u'०': u'0', u'१': u'1', u'२': u'2', u'३': u'3', u'४': u'4', u'५': u'5', u'६': u'6', u'७': u'7', u'८': u'8', u'९': u'9'}
 kannada = {u'0': u'0', u'౧': u'1', u'౨': u'2', u'౩': u'3', u'౪': u'4', u'౫': u'5', u'౬': u'6', u'౭': u'7', u'౮': u'8', u'౯': u'9'}
-malayam = {u'൦': u'0', u'൧': u'1', u'൨': u'2', u'൩': u'3', u'൪': u'4', u'൫': u'5', u'൬': u'6', u'൬': u'7', u'൮': u'8', u'൯': u'9'}
+malayam = {u'൦': u'0', u'൧': u'1', u'൨': u'2', u'൩': u'3', u'൪': u'4', u'൫': u'5', u'൬': u'6', u'൭': u'7', u'൮': u'8', u'൯': u'9'}
 
 if locale in ['ar_SA.utf8', 'ar_YE.utf8', 'ar_AE.utf8', 'ar_SY.utf8', 'ar_OM.utf8', 'ar_JO.utf8', 'ar_IQ.utf8', 'ar_KW.utf8', 'ar_LB.utf8', 'ar_IQ.utf8', 'ar_SD.utf8', 'ar_EG.utf8', 'fa_IR.utf8']:
     localDic = indic

--- a/numParser.py
+++ b/numParser.py
@@ -24,16 +24,18 @@ elif locale[0:3] in {'ml_'}:
 else:
     localDic = arabic
 
-standardDic = {v:k for k, v in localDic.items()}
+standardDic = {v: k for k, v in localDic.items()}
+
 
 def local(standardString):
     result = u''
     for c in standardString:
         if c.encode('utf-8') in standardDic:
-            result =  result + standardDic[c]
+            result = result + standardDic[c]
         else:
             result = result + c
     return result
+
 
 def standard(localString):
     localString = localString.decode('utf-8')


### PR DESCRIPTION
Implements #47 

**Changes and Additions**
1) `calculate.py`
2) `layout.py`
3) `numParser.py`

**Updates**
The activity now based on the `LANG` env variable, chooses the display numerals on the calculator layout. Conversions between the standard form the Indic/Indian form is done when required and the result is displayed in the local numerals.

As per checklist:
- [x] prove the source code changes are not present now,
- [x] prove the feature is not present now in some other form,
After going through the codebase, I realized no such feature has been implemented.
- [x] describe a test case,
Rather than use `os.getenv('LANG', 'en_US.utf8')`, we can test the feature by assigning a `LANG` in the `numParser.py` script. On running the activity, the layout is shown with local numerals. 
Tested with Malyalam numerals and performed different mathematical 
- [x] verify the test case,
Attached screenshot for reference
![Screenshot from 2019-06-19 17-59-58](https://user-images.githubusercontent.com/34597895/59765658-2a23b180-92bc-11e9-9284-1c3afe5e6960.png)
- [x] make a pull request.
- [ ] merge PR,