### PR TITLE
Set buttons to vertically expand to fill grid

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -246,6 +246,7 @@ class CalcLayout:
         for x, y, w, h, cap, bgcol, cb in self.button_data:
             button = self.create_button(
                 _(cap), cb, self.col_white, bgcol, w, h)
+            button.set_vexpand(True)
             self.buttons[cap] = button
             self.pad.attach(button, x, y, w, h)
 


### PR DESCRIPTION
By setting button.set_vexpand(True), buttons in the Gtk.Grid now fill the available vertical space.

Fixes #43
Related #66

@chimosky @sourabhaa