### PR TITLE
Fix warnings

### DIFF
--- a/toolbars.py
+++ b/toolbars.py
@@ -391,13 +391,13 @@ class MiscToolbar(Gtk.Toolbar):
         else:
             target_toolbar = self._target_toolbar
 
-        target_toolbar.insert(self._line_separator1, -1)
-        target_toolbar.insert(self._plot_button, -1)
-        target_toolbar.insert(self._line_separator2, -1)
-        target_toolbar.insert(self._angle_button, -1)
-        target_toolbar.insert(self._format_button, -1)
-        target_toolbar.insert(self._digits_button, -1)
-        target_toolbar.insert(self._base_button, -1)
+        for item in [self._plot_button, self._line_separator1,
+                     self._line_separator2, self._angle_button,
+                     self._format_button, self._digits_button,
+                     self._base_button]:
+            if item.get_parent():
+                item.get_parent().remove(item)
+            target_toolbar.insert(item, -1)
 
     def _remove_buttons(self, toolbar):
         for item in [self._plot_button, self._line_separator1,

--- a/toolbars.py
+++ b/toolbars.py
@@ -404,7 +404,8 @@ class MiscToolbar(Gtk.Toolbar):
                      self._line_separator2, self._angle_button,
                      self._format_button, self._digits_button,
                      self._base_button]:
-            toolbar.remove(item)
+            if item.get_parent() == toolbar:
+                toolbar.remove(item)
 
     def update_angle_type(self, text, calc):
         var = calc.parser.get_var('angle_scaling')


### PR DESCRIPTION
Aim is to fix 3 Gtk-CRITICAL warnings:
`(sugar-activity3:4323): Gtk-WARNING **: 06:18:13.071: Can't set a parent on widget which has a parent`

`(sugar-activity3:5074): Gtk-CRITICAL **: 07:43:28.327: gtk_container_propagate_draw: assertion '_gtk_widget_get_parent (child) == GTK_WIDGET (container)' failed`

`(sugar-activity3:5548): Gtk-CRITICAL **: 07:59:30.659: gtk_toolbar_remove: assertion 'content_to_remove != NULL' failed`

@chimosky @sourabhaa