### PR TITLE
Fix display issue in 1280x720

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -453,7 +453,6 @@ class CalcLayout:
     def modify_button_appearance(self, button, fgcol, bgcol, width, height):
         """Modify button style."""
         width = 50 * width
-        height = 50 * height
         button.get_child().set_size_request(width, height)
         button.get_child().modify_font(self.button_font)
         button.get_child().modify_fg(Gtk.StateType.NORMAL, fgcol)


### PR DESCRIPTION
Since the buttons are set to vertically expand
at line [249](https://github.com/sugarlabs/calculate-activity/blob/b5067c32bdd4fae9cc7166ce26bc8de62993d165/layout.py#L249)
explicitly increasing height 50times doesn't have any effect 
By removing height size fixed the issue

I have tested this on display sizes of

```
1920x1080
1680x1050
1440x900
1280x1024
1280x800
1280x720
1024x768
```