### PR TITLE
corrected escape sequence

### DIFF
--- a/astparser.py
+++ b/astparser.py
@@ -221,9 +221,9 @@ class AstParser:
     POST_OPS = (
     )
 
-    FLOAT_REGEXP_STR = '([+-]?[0-9]*\.?[0-9]+([eE][+-]?[0-9]+)?)'
+    FLOAT_REGEXP_STR = r'([+-]?[0-9]*\.?[0-9]+([eE][+-]?[0-9]+)?)'
     FLOAT_REGEXP = re.compile(FLOAT_REGEXP_STR)
-    RANGE_REGEXP = re.compile('=([^,]+)\.\.([^,]+)')
+    RANGE_REGEXP = re.compile(r'=([^,]+)\.\.([^,]+)')
 
     # Unary and binary operator maps.
     # Mappings to a string will be replaced by calls to MathLib functions


### PR DESCRIPTION
Fixes: #78 

## Description

This PR updates two regular expression strings in `Calculate.activity/astparser.py` to use Python raw string notation (`r''`).  
This prevents unintended escape sequence issues and resolves warnings raised by the Python interpreter when running the script.

## Why this change?

Using raw strings in regular expressions ensures that backslashes (`\`) are treated literally, avoiding misinterpretation as Python escape sequences.  
This is especially important for patterns like `\.` (literal dot) or `\d`, etc.

## Testing

- Ran the script with Python warnings enabled:
  ```bash
  python3 -Wall astparser.py

