### PR TITLE
Fix GTK4 Port: Layout, Focus Management, and Arrow Navigation

### DIFF
--- a/activity.css
+++ b/activity.css
@@ -1,0 +1,65 @@
+/* Calculate Activity - Custom Styles */
+
+.calc-button {
+    /* Remove default background gradients so custom background-color takes effect */
+    background-image: none;
+    color: #ffffff;
+    font-weight: bold;
+}
+
+/* Originally col_gray1: 0.76, 0.76, 0.76 */
+.calc-action-btn {
+    background-color: #c2c2c2; 
+}
+.calc-action-btn:hover {
+    background-color: #d2d2d2;
+}
+
+/* Originally col_gray2: 0.50, 0.50, 0.50 */
+.calc-numpad-btn {
+    background-color: #808080;
+}
+.calc-numpad-btn:hover {
+    background-color: #909090;
+}
+
+/* Originally col_gray3: 0.25, 0.25, 0.25 */
+.calc-operator-btn {
+    background-color: #404040;
+}
+.calc-operator-btn:hover {
+    background-color: #505050;
+}
+
+.calc-danger-btn {
+    background-color: #ff0000;
+}
+.calc-danger-btn:hover {
+    background-color: #ff3333;
+}
+
+.calc-white-btn {
+    background-color: #ffffff;
+    color: #000000;
+}
+.calc-white-btn:hover {
+    background-color: #f0f0f0;
+}
+
+/* Original eb.modify_bg(Gtk.StateType.NORMAL, self.col_black) */
+.calc-display {
+    background-color: #000000;
+}
+
+/* Original label1.modify_fg(Gtk.StateType.NORMAL, self.col_white) */
+.calc-label {
+    color: #ffffff;
+}
+
+/* Original text_entry.modify_bg(Gtk.StateType.INSENSITIVE, self.col_black) */
+.calc-entry {
+    background-color: #000000;
+    color: #ffffff;
+    font-weight: bold;
+}
+

--- a/astparser.py
+++ b/astparser.py
@@ -46,7 +46,8 @@ class ParserError(Exception):
 
     def __init__(self, msg, start, eqn, end=None):
         self._msg = msg
-        self.eqn = eqn
+        # Handle non-string/bytes eqn values gracefully in Python 3.14+ AST exceptions
+        self.eqn = eqn if isinstance(eqn, (str, bytes)) else ""
         self.set_range(start, end)
 
     def get_range(self):
@@ -141,8 +142,9 @@ class Helper:
     def get_help(self, topic=None):
         if isinstance(topic, ast.Name):
             topic = topic.id
-        elif isinstance(topic, ast.Str):
-            topic = topic.s
+        # ast.Str was removed in Python 3.14, so we use ast.Constant
+        elif isinstance(topic, ast.Constant) and isinstance(topic.value, str):
+            topic = topic.value
         elif type(topic) not in (bytes, str) or \
                 len(topic) == 0:
             return _("Use help(test) for help about 'test',"
@@ -221,9 +223,9 @@ class AstParser:
     POST_OPS = (
     )
 
-    FLOAT_REGEXP_STR = '([+-]?[0-9]*\.?[0-9]+([eE][+-]?[0-9]+)?)'
+    FLOAT_REGEXP_STR = r'([+-]?[0-9]*\.?[0-9]+([eE][+-]?[0-9]+)?)'
     FLOAT_REGEXP = re.compile(FLOAT_REGEXP_STR)
-    RANGE_REGEXP = re.compile('=([^,]+)\.\.([^,]+)')
+    RANGE_REGEXP = re.compile(r'=([^,]+)\.\.([^,]+)')
 
     # Unary and binary operator maps.
     # Mappings to a string will be replaced by calls to MathLib functions
@@ -421,8 +423,8 @@ class AstParser:
             if val == self._ARG_STRING:
                 if isinstance(arg, ast.Name):
                     return arg.id
-                elif isinstance(arg, ast.Str):
-                    return arg.s
+                elif isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    return arg.value
                 else:
                     logging.error('Unable to resolve special arg %r', arg)
         else:
@@ -490,11 +492,8 @@ class AstParser:
                 msg = str(e)
                 raise ArgumentError(msg)
 
-        elif isinstance(node, ast.Num):
-            return node.n
-
-        elif isinstance(node, ast.Str):
-            return node.s
+        elif isinstance(node, ast.Constant):
+            return node.value
 
         elif isinstance(node, ast.Tuple):
             ls = [self._process_node(i, state) for i in node.elts]
@@ -596,21 +595,22 @@ class AstParser:
 
     def _parse_func(self, node, level):
         if isinstance(node, ast.BinOp):
-            if isinstance(node.left, ast.Num) and isinstance(node.right,
-                                                             ast.Num):
-                func = self.BINOP_MAP[type(node.op)]
-                ans = func(node.left.n, node.right.n)
-                ret = ast.Num()
-                ret.n = ans
-                return ret
-            else:
-                return None
+            # ast.Num was removed in Python 3.14; use ast.Constant instead.
+            # We must ensure values are numeric, as ast.Constant can hold any type.
+            if (isinstance(node.left, ast.Constant) and
+                    isinstance(node.right, ast.Constant)):
+                if (isinstance(node.left.value, (int, float, complex)) and
+                        isinstance(node.right.value, (int, float, complex))):
+                    func = self.BINOP_MAP[type(node.op)]
+                    ans = func(node.left.value, node.right.value)
+                    return ast.Constant(value=ans)
+            return None
         elif isinstance(node, ast.Name):
             if node.id in self._namespace:
                 var = self.get_var(node.id)
-                ret = ast.Num()
-                ret.n = var
-                return ret
+                # ast.Num was removed in Python 3.14; returning ast.Constant.
+                if isinstance(var, (int, float, complex)):
+                    return ast.Constant(value=var)
 
     def parse_symbolic(self, tree):
         '''
@@ -677,8 +677,8 @@ class AstParser:
             raise e
         except Exception as e:
             logging.error('Internal error (%s): %s', type(e), str(e))
-            msg = _('Internal error')
-            raise ParseError(msg, 0, eqn)
+            msg = _('Internal error: %s') % str(e)
+            raise ParseError(msg, 0, "")
 
         self._used_var_ofs = state.used_var_ofs
 
@@ -729,9 +729,6 @@ if __name__ == '__main__':
     p.print_tree(tree)
 #    p.set_var('apples', 123)
     p.parse_symbolic(tree)
-#    num = ast.Num()
-#    num.n = 123
-#    p.replace_variable(tree, 'apples', num)
     print('Tree after:')
     p.print_tree(tree)
 

--- a/calculate.py
+++ b/calculate.py
@@ -26,13 +26,14 @@ import logging
 _logger = logging.getLogger('Calculate')
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
 import base64
 
-import sugar3.profile
-from sugar3.graphics.xocolor import XoColor
+import sugar4.profile
+from sugar4.graphics.xocolor import XoColor
+from sugar4.graphics import style as sugar_style
 
 from shareable_activity import ShareableActivity
 from layout import CalcLayout
@@ -62,13 +63,6 @@ def findchar(text, chars, ofs=0):
     return -1
 
 
-def _textview_realize_cb(widget):
-    '''Change textview properties once window is created.'''
-    win = widget.get_window(Gtk.TextWindowType.TEXT)
-    win.set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
-    return False
-
-
 class Equation:
 
     def __init__(self, label=None, eqn=None, res=None, col=None, owner=None,
@@ -92,7 +86,7 @@ class Equation:
 
     def __str__(self):
         if isinstance(self.result, SVGImage):
-            svg_data = "<svg>" + base64.b64encode(self.result.get_svg_data())
+            svg_data = "<svg>" + base64.b64encode(self.result.get_svg_data()).decode('utf-8')
             return "%s;%s;%s;%s;%s\n" % \
                 (self.label, self.equation, svg_data,
                  self.color.to_string(), self.owner)
@@ -244,32 +238,50 @@ class Equation:
             return self.result.get_image()
 
         w = Gtk.TextView()
-        w.modify_base(
-            Gtk.StateType.NORMAL, Gdk.color_parse(self.color.get_fill_color()))
-        w.modify_bg(
-            Gtk.StateType.NORMAL,
-            Gdk.color_parse(self.color.get_stroke_color()))
+        w.set_editable(False)
+        w.set_cursor_visible(False)
+        
+        fill_color = self.color.get_fill_color()
+        stroke_color = self.color.get_stroke_color()
+        
+        css_str = """
+        textview {
+            background-color: %s;
+            color: %s;
+        }
+        textview text {
+            background-color: %s;
+            color: %s;
+            min-height: 20px;
+        }
+        """ % (stroke_color, fill_color, stroke_color, fill_color)
+        
+        sugar_style.apply_css_to_widget(w, css_str)
+        
         w.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        w.set_border_window_size(Gtk.TextWindowType.LEFT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.RIGHT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.TOP, 4)
-        w.set_border_window_size(Gtk.TextWindowType.BOTTOM, 4)
-        w.connect('realize', _textview_realize_cb)
+        w.set_left_margin(4)
+        w.set_right_margin(4)
+        w.set_top_margin(4)
+        w.set_bottom_margin(4)
+        w.set_cursor_from_name("pointer")
         buf = w.get_buffer()
 
         tagsmall = buf.create_tag(font=CalcLayout.FONT_SMALL)
         tagsmallnarrow = buf.create_tag(font=CalcLayout.FONT_SMALL_NARROW)
         tagbig = buf.create_tag(font=CalcLayout.FONT_BIG,
                                 justification=Gtk.Justification.RIGHT)
-        # TODO Fix for old Sugar 0.82 builds, red_float not available
-        bright = (
-            Gdk.color_parse(self.color.get_fill_color()).red_float +
-            Gdk.color_parse(self.color.get_fill_color()).green_float +
-            Gdk.color_parse(self.color.get_fill_color()).blue_float) / 3.0
-        if bright < 0.5:
-            col = 'white'
+        
+        # Calculate brightness
+        c = Gdk.RGBA()
+        if c.parse(fill_color):
+            bright = (c.red + c.green + c.blue) / 3.0
+            if bright < 0.5:
+                col = 'white'
+            else:
+                col = 'black'
         else:
             col = 'black'
+            
         tagcolor = buf.create_tag(foreground=col)
 
         # Add label, equation and result
@@ -279,13 +291,22 @@ class Equation:
         eqnstr = '%s\n' % str(self.equation)
         self.append_with_superscript_tags(buf, eqnstr, tagsmall)
 
-        resstr = self.ml.format_number(self.result)
-        resstr = str(resstr).rstrip('0').rstrip('.') \
-            if '.' in resstr else resstr
+        try:
+            resstr = self.ml.format_number(self.result)
+        except Exception:
+            resstr = str(self.result)
+            
+        resstr = str(resstr)
+        resstr = resstr.rstrip('0').rstrip('.') if '.' in resstr else resstr
+        
+        if not resstr or resstr == "None":
+             resstr = ""
+
         if len(resstr) > 30:
             restag = tagsmall
         else:
             restag = tagbig
+            
         self.append_with_superscript_tags(buf, resstr, restag)
 
         buf.apply_tag(tagcolor, buf.get_start_iter(), buf.get_end_iter())
@@ -353,6 +374,15 @@ class Calculate(ShareableActivity):
         'End': lambda o: o.expand_selection(1000),
     }
 
+    KP_MAP = {
+        "KP_Enter": "Return",
+        "KP_Add": "plus",
+        "KP_Subtract": "minus",
+        "KP_Multiply": "multiply",
+        "KP_Divide": "divide",
+        "KP_Decimal": "period"
+    }
+
     IDENTIFIER_CHARS = \
         "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_ "
 
@@ -374,7 +404,7 @@ class Calculate(ShareableActivity):
         self.KEYMAP['divide'] = self.ml.div_sym
         self.KEYMAP['equal'] = self.ml.equ_sym
 
-        self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        self.clipboard = Gdk.Display.get_default().get_clipboard()
         self.select_reason = self.SELECT_SELECT
         self.buffer = ""
         self.showing_version = 0
@@ -382,15 +412,21 @@ class Calculate(ShareableActivity):
         self.ans_inserted = False
         self.show_vars = False
 
-        self.connect("key_press_event", self.keypress_cb)
-        self.connect("destroy", self.cleanup_cb)
-        self.color = sugar3.profile.get_color()
+        self._key_controller = Gtk.EventControllerKey()
+        self._key_controller.connect("key-pressed", self.keypress_cb)
+        
+        # Intercept keystrokes BEFORE the text entry swallows them
+        self._key_controller.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        
+        self.add_controller(self._key_controller)
+        
+        self.color = sugar4.profile.get_color()
 
         self.layout = CalcLayout(self)
         self.label_entry = self.layout.label_entry
         self.text_entry = self.layout.text_entry
-        self.last_eq_sig = None
         self.last_eqn_textview = None
+        self.last_eqn_controller = None
 
         self.reset()
         self.layout.show_it()
@@ -398,12 +434,6 @@ class Calculate(ShareableActivity):
         self.connect('joined', self._joined_cb)
 
         self.parser.log_debug_info()
-
-    def ignore_key_cb(self, widget, event):
-        return True
-
-    def cleanup_cb(self, arg):
-        _logger.debug('Cleaning up...')
 
     def equation_pressed_cb(self, eqn):
         """Callback for when an equation box is clicked."""
@@ -427,14 +457,15 @@ class Calculate(ShareableActivity):
     def set_last_equation(self, eqn):
         """Set the 'last equation' TextView."""
 
-        if self.last_eq_sig is not None:
-            self.layout.last_eq.disconnect(self.last_eq_sig)
-            self.last_eq_sig = None
+        if self.last_eqn_controller is not None:
+            self.layout.last_eq.remove_controller(self.last_eqn_controller)
+            self.last_eqn_controller = None
 
         if not isinstance(eqn.result, ParserError):
-            self.last_eq_sig = self.layout.last_eq.connect(
-                'button-press-event',
-                lambda a1, a2, e: self.equation_pressed_cb(e), eqn)
+            self.last_eqn_controller = Gtk.GestureClick.new()
+            self.last_eqn_controller.set_button(1)
+            self.last_eqn_controller.connect('pressed', lambda gesture, n_press, x, y: self.equation_pressed_cb(eqn))
+            self.layout.last_eq.add_controller(self.last_eqn_controller)
 
         self.layout.last_eq.set_buffer(eqn.create_lasteq_textbuf())
 
@@ -490,8 +521,10 @@ class Calculate(ShareableActivity):
 
         own = (eq.owner == self.get_owner_id())
         w = eq.create_history_object()
-        w.connect('button-press-event', lambda w,
-                  e: self.equation_pressed_cb(eq))
+        click_gesture = Gtk.GestureClick.new()
+        click_gesture.set_button(1)
+        click_gesture.connect('pressed', lambda gesture, n_press, x, y: self.equation_pressed_cb(eq))
+        w.add_controller(click_gesture)
         if drawlasteq:
             self.set_last_equation(eq)
 
@@ -520,8 +553,10 @@ class Calculate(ShareableActivity):
             res = e
             self.showing_error = True
 
-        if isinstance(res, str) and res.find('</svg>') > -1:
+        if isinstance(res, bytes) and b'</svg>' in res:
             res = SVGImage(data=res)
+        elif isinstance(res, str) and '</svg>' in res:
+            res = SVGImage(data=res.encode('utf-8'))
 
         _logger.debug('Result: %r', res)
 
@@ -551,7 +586,7 @@ class Calculate(ShareableActivity):
                            self.get_owner_id(), ml=self.ml)
             self.set_error_equation(eqn)
         else:
-            eqn = Equation(label, _n(s), _n(str(res)), self.color,
+            eqn = Equation(label, _n(s), res, self.color,
                            self.get_owner_id(), ml=self.ml)
             self.add_equation(eqn, drawlasteq=True, tree=tree)
             self.send_message("add_eq", value=str(eqn))
@@ -576,28 +611,40 @@ class Calculate(ShareableActivity):
         if name in reserved:
             return None
         w = Gtk.TextView()
-        w.modify_base(
-            Gtk.StateType.NORMAL, Gdk.color_parse(self.color.get_fill_color()))
-        w.modify_bg(
-            Gtk.StateType.NORMAL,
-            Gdk.color_parse(self.color.get_stroke_color()))
+        w.set_editable(False)
+        w.set_cursor_visible(False)
+        fill_color = self.color.get_fill_color()
+        stroke_color = self.color.get_stroke_color()
+        
+        css_str = """
+        textview {
+            background-color: %s;
+            color: %s;
+        }
+        textview text {
+            background-color: %s;
+            color: %s;
+        }
+        """ % (fill_color, stroke_color, fill_color, stroke_color)
+        sugar_style.apply_css_to_widget(w, css_str)
+
         w.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        w.set_border_window_size(Gtk.TextWindowType.LEFT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.RIGHT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.TOP, 4)
-        w.set_border_window_size(Gtk.TextWindowType.BOTTOM, 4)
-        w.connect('realize', _textview_realize_cb)
+        w.set_left_margin(4)
+        w.set_right_margin(4)
+        w.set_top_margin(4)
+        w.set_bottom_margin(4)
+        w.set_cursor_from_name("pointer")
         buf = w.get_buffer()
 
-        # TODO Fix for old Sugar 0.82 builds, red_float not available
-        bright = (
-            Gdk.color_parse(self.color.get_fill_color()).red_float +
-            Gdk.color_parse(self.color.get_fill_color()).green_float +
-            Gdk.color_parse(self.color.get_fill_color()).blue_float) / 3.0
-        if bright < 0.5:
-            col = Gdk.color_parse('white')
+        c = Gdk.RGBA()
+        if c.parse(fill_color):
+            bright = (c.red + c.green + c.blue) / 3.0
+            if bright < 0.5:
+                col = 'white'
+            else:
+                col = 'black'
         else:
-            col = Gdk.color_parse('black')
+            col = 'black'
 
         tag = buf.create_tag(font=CalcLayout.FONT_SMALL_NARROW,
                              foreground=col)
@@ -792,67 +839,80 @@ class Calculate(ShareableActivity):
 
     def text_copy(self):
         if self.layout.graph_selected is not None:
-            self.clipboard.set_image(
-                self.layout.graph_selected.get_child().get_pixbuf())
-            self.layout.toggle_select_graph(self.layout.graph_selected)
+            # get_paintable() returns a Gdk.Texture for static images
+            paintable = self.layout.graph_selected.get_child().get_paintable()
+            if isinstance(paintable, Gdk.Texture):
+                self.clipboard.set_texture(paintable)
+                self.layout.toggle_select_graph(self.layout.graph_selected)
+            else:
+                _logger.warning("Failed to copy graph: not a Gdk.Texture")
         else:
             str = self.text_entry.get_text()
             sel = self.text_entry.get_selection_bounds()
             # _logger.info('text_copy, sel: %r, str: %s', sel, str)
             if len(sel) == 2:
                 (start, end) = sel
-                self.clipboard.set_text(str[start:end], -1)
+                self.clipboard.set_text(str[start:end])
 
     def text_select_all(self):
         end = self.text_entry.get_text_length()
         self.text_entry.select_region(0, end)
 
-    def get_clipboard_text(self):
-        text = self.clipboard.wait_for_text()
-        if text is None:
-            return ""
-        else:
-            return text
-
     def text_paste(self):
-        self.button_pressed(self.TYPE_TEXT, self.get_clipboard_text())
+        self.clipboard.read_text_async(None, self._on_paste_text_received, None)
+
+    def _on_paste_text_received(self, clipboard, result, user_data):
+        try:
+            text = clipboard.read_text_finish(result)
+            if text:
+                self.button_pressed(self.TYPE_TEXT, text)
+        except Exception as e:
+            _logger.error("Error pasting text: %s", e)
 
     def text_cut(self):
         self.text_copy()
         self.remove_character(1)
 
-    def keypress_cb(self, widget, event):
-        if not self.text_entry.is_focus():
-            return
+    def keypress_cb(self, controller, keyval, keycode, state):
+        if hasattr(self, 'layout') and hasattr(self.layout, 'label_entry'):
+            if self.layout.label_entry.get_state_flags() & Gtk.StateFlags.FOCUS_WITHIN:
+                return False
 
-        key = Gdk.keyval_name(event.keyval)
-        if event.hardware_keycode == 219:
-            if (event.get_state() & Gdk.ModifierType.SHIFT_MASK):
-                key = 'divide'
+        keyname = Gdk.keyval_name(keyval)
+        
+        is_ctrl = (state & Gdk.ModifierType.CONTROL_MASK)
+        is_shift = (state & Gdk.ModifierType.SHIFT_MASK) and not is_ctrl
+
+        if is_ctrl:
+            if keyname in self.CTRL_KEYMAP:
+                self.CTRL_KEYMAP[keyname](self)
+                return True
+        elif is_shift:
+            if keyname in self.SHIFT_KEYMAP:
+                self.SHIFT_KEYMAP[keyname](self)
+                return True
+
+        if "KP_" in keyname:
+            if keyname in self.KP_MAP:
+                keyname = self.KP_MAP[keyname]
+
+        if keyname in self.KEYMAP:
+            action = self.KEYMAP[keyname]
+            if callable(action):
+                action(self)
             else:
-                key = 'multiply'
-        _logger.debug('Key: %s (%r, %r)', key,
-                      event.keyval, event.hardware_keycode)
+                self.button_pressed(self.TYPE_TEXT, action)
+            return True
 
-        if event.get_state() & Gdk.ModifierType.CONTROL_MASK:
-            if key in self.CTRL_KEYMAP:
-                f = self.CTRL_KEYMAP[key]
-                return f(self)
-        elif (event.get_state() & Gdk.ModifierType.SHIFT_MASK) and \
-                key in self.SHIFT_KEYMAP:
-            f = self.SHIFT_KEYMAP[key]
-            return f(self)
-        elif str(key) in self.IDENTIFIER_CHARS:
-            self.button_pressed(self.TYPE_TEXT, key)
-        elif key in self.KEYMAP:
-            f = self.KEYMAP[key]
-            if isinstance(f, str) or \
-                    isinstance(f, str):
-                self.button_pressed(self.TYPE_TEXT, f)
-            else:
-                return f(self)
+        # Fallback for numpad keys and identifier characters
+        uni = Gdk.keyval_to_unicode(keyval)
+        if uni:
+            char = chr(uni)
+            if char in self.IDENTIFIER_CHARS:
+                self.button_pressed(self.TYPE_TEXT, char)
+                return True
 
-        return True
+        return False
 
     def get_older(self):
         self.showing_version = max(0, self.showing_version - 1)
@@ -956,7 +1016,7 @@ class Calculate(ShareableActivity):
             self.clear_equations()
             for eq_str in value:
                 _logger.debug('receive_message: %s', str(eq_str))
-                self.add_equation(Equation(eqnstr=str(eq_str)), ml=self.ml)
+                self.add_equation(Equation(eqnstr=str(eq_str), ml=self.ml))
 
     def _joined_cb(self, gobj):
         _logger.debug('Requesting synchronization')
@@ -970,14 +1030,3 @@ class Calculate(ShareableActivity):
             return self.ml.format_number(ans)
         else:
             return ''
-
-
-def main():
-    win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
-    Calculate(win)
-    Gtk.main()
-    return 0
-
-
-if __name__ == "__main__":
-    main()

--- a/calculate.py
+++ b/calculate.py
@@ -30,6 +30,7 @@ gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
 import base64
+import os
 
 import sugar4.profile
 from sugar4.graphics.xocolor import XoColor
@@ -421,6 +422,17 @@ class Calculate(ShareableActivity):
         self.add_controller(self._key_controller)
         
         self.color = sugar4.profile.get_color()
+
+        # Load activity-specific CSS
+        css_provider = Gtk.CssProvider()
+        css_path = os.path.join(os.environ.get("SUGAR_BUNDLE_PATH", os.getcwd()), "activity.css")
+        if os.path.exists(css_path):
+            css_provider.load_from_path(css_path)
+            Gtk.StyleContext.add_provider_for_display(
+                Gdk.Display.get_default(),
+                css_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
 
         self.layout = CalcLayout(self)
         self.label_entry = self.layout.label_entry

--- a/layout.py
+++ b/layout.py
@@ -20,13 +20,9 @@
 
 from gettext import gettext as _
 import gi
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
-from gi.repository import Gdk
-from gi.repository import Pango
-import sugar3.profile
-from sugar3.graphics.style import FONT_SIZE
-from sugar3.graphics.combobox import ComboBox
+gi.require_version('Gtk', '4.0')
+from gi.repository import Gtk, Gdk
+from sugar4.graphics.style import FONT_SIZE
 from toolbars import EditToolbar
 from toolbars import AlgebraToolbar
 from toolbars import TrigonometryToolbar
@@ -36,9 +32,9 @@ from toolbars import MiscToolbar
 from numerals import local as _n
 
 try:
-    from sugar3.graphics.toolbarbox import ToolbarButton, ToolbarBox
-    from sugar3.activity.widgets import ActivityToolbarButton
-    from sugar3.activity.widgets import StopButton
+    from sugar4.graphics.toolbarbox import ToolbarButton, ToolbarBox
+    from sugar4.activity.widgets import ActivityToolbarButton
+    from sugar4.activity.widgets import StopButton
 except ImportError:
     pass
 
@@ -67,7 +63,7 @@ class CalcLayout:
         self.create_dialog()
 
     def create_color(self, rf, gf, bf):
-        return Gdk.Color.from_floats(rf, gf, bf)
+        return Gdk.RGBA(rf, gf, bf, 1.0)
 
     def create_button_data(self):
         """Create a list with button information. We need to do that here
@@ -138,285 +134,248 @@ class CalcLayout:
 
 # Toolbar
         self._toolbar_box = ToolbarBox()
+        
         activity_button = ActivityToolbarButton(self._parent)
-        self._toolbar_box.toolbar.insert(activity_button, 0)
+        self._toolbar_box.get_toolbar().append(activity_button)
 
-        def append(icon_name, label, page, position):
-            toolbar_button = ToolbarButton()
-            toolbar_button.props.page = page
-            toolbar_button.props.icon_name = icon_name
-            toolbar_button.props.label = label
-            self._toolbar_box.toolbar.insert(toolbar_button, position)
-        append('toolbar-edit',
-               _('Edit'),
-               EditToolbar(self._parent),
-               -1)
-        append('toolbar-algebra',
-               _('Algebra'),
-               AlgebraToolbar(self._parent),
-               -1)
-        append('toolbar-trigonometry',
-               _('Trigonometry'),
-               TrigonometryToolbar(self._parent),
-               -1)
-        append('toolbar-boolean',
-               _('Boolean'),
-               BooleanToolbar(self._parent),
-               -1)
-        self._misc_toolbar = MiscToolbar(
-            self._parent,
-            target_toolbar=self._toolbar_box.toolbar)
-        append('toolbar-constants',
-               _('Miscellaneous'),
-               self._misc_toolbar,
-               5)
-        self._stop_separator = Gtk.SeparatorToolItem()
-        self._stop_separator.props.draw = False
-        self._stop_separator.set_expand(True)
-        self._stop_separator.show()
-        self._toolbar_box.toolbar.insert(self._stop_separator, -1)
-        self._stop = StopButton(self._parent)
-        self._toolbar_box.toolbar.insert(self._stop, -1)
-        self._toolbar_box.show_all()
-        self._parent.set_toolbar_box(self._toolbar_box)
+        def append_toolbar(icon_name, label, page):
+            page.set_hexpand(True)
+            toolbar_button = ToolbarButton(page=page, icon_name=icon_name)
+            toolbar_button.set_tooltip_text(label)
+            if toolbar_button.page_widget is not None:
+                toolbar_button.page_widget.set_hexpand(True)
+            self._toolbar_box.get_toolbar().append(toolbar_button)
 
-# Some layout constants
-        self.input_font = Pango.FontDescription(
-            'sans bold %d' % (FONT_SIZE * 4))
-        self.button_font = Pango.FontDescription(
-            'sans bold %d' % (FONT_SIZE * 4))
+        append_toolbar('toolbar-edit',
+                       _('Edit'),
+                       EditToolbar(self._parent))
+        append_toolbar('toolbar-algebra',
+                       _('Algebra'),
+                       AlgebraToolbar(self._parent))
+        append_toolbar('toolbar-trigonometry',
+                       _('Trigonometry'),
+                       TrigonometryToolbar(self._parent))
+        append_toolbar('toolbar-boolean',
+                       _('Boolean'),
+                       BooleanToolbar(self._parent))
+        self._misc_toolbar = MiscToolbar(self._parent)
+        append_toolbar('toolbar-constants',
+                       _('Miscellaneous'),
+                       self._misc_toolbar)
+
+        spacer = Gtk.Box()
+        spacer.set_hexpand(True)
+        self._toolbar_box.get_toolbar().append(spacer)
+
+        stop_button = StopButton(self._parent)
+        self._toolbar_box.get_toolbar().append(stop_button)
+
+        if hasattr(self._parent, 'set_toolbar_box'):
+            self._parent.set_toolbar_box(self._toolbar_box)
+
+        # Layout constants
         self.col_white = self.create_color(1.00, 1.00, 1.00)
-        self.col_gray1 = self.create_color(0.76, 0.76, 0.76)
-        self.col_gray2 = self.create_color(0.50, 0.50, 0.50)
+        self.col_gray1 = self.create_color(0.85, 0.85, 0.85)
+        self.col_gray2 = self.create_color(0.65, 0.65, 0.65)
         self.col_gray3 = self.create_color(0.25, 0.25, 0.25)
-        self.col_black = self.create_color(0.00, 0.00, 0.00)
         self.col_red = self.create_color(1.00, 0.00, 0.00)
 
-# Big - Table, 16 rows, 10 columns, homogeneously divided
+
+        # Big - Grid
         self.grid = Gtk.Grid()
         self.grid.set_column_homogeneous(True)
         self.grid.set_row_spacing(0)
         self.grid.set_column_spacing(4)
 
-# Left part: container and input
+        # Left part: container and input
         vc1 = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         hc1 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
-        eb = Gtk.EventBox()
-        eb.add(hc1)
-        eb.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        eb.set_border_width(12)
-        eb2 = Gtk.EventBox()
-        eb2.add(eb)
-        eb2.modify_bg(Gtk.StateType.NORMAL, self.col_black)
+        
+        eb = Gtk.Box()
+        eb.add_css_class("calc-display")
+        eb.append(hc1)
+        
+        eb.set_margin_top(4)
+        eb.set_margin_bottom(4)
+        
         label1 = Gtk.Label(label=_('Label:'))
-        label1.modify_fg(Gtk.StateType.NORMAL, self.col_white)
-        label1.set_alignment(1, 0.5)
-        hc1.pack_start(label1, expand=False, fill=False, padding=10)
+        label1.add_css_class("calc-label")
+        label1.set_xalign(1.0)
+        
+        hc1.append(label1)
+        
         self.label_entry = Gtk.Entry()
-        self.label_entry.modify_bg(Gtk.StateType.INSENSITIVE, self.col_black)
-        hc1.pack_start(self.label_entry, expand=True, fill=True, padding=0)
-        vc1.pack_start(eb2, False, True, 0)
+        self.label_entry.set_hexpand(True)
+        hc1.append(self.label_entry)
+        
+        vc1.append(eb)
 
         self.text_entry = Gtk.Entry()
-        try:
-            self.text_entry.props.im_module = 'gtk-im-context-simple'
-        except AttributeError:
-            pass
         self.text_entry.set_size_request(-1, 75)
-        self.text_entry.connect('key_press_event', self._parent.ignore_key_cb)
-        self.text_entry.modify_font(self.input_font)
-        self.text_entry.modify_bg(Gtk.StateType.INSENSITIVE, self.col_black)
-        eb = Gtk.EventBox()
-        eb.add(self.text_entry)
-        eb.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        eb.set_border_width(12)
-        eb2 = Gtk.EventBox()
-        eb2.add(eb)
-        eb2.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        vc1.pack_start(eb2, expand=True, fill=True, padding=0)
+        self.text_entry.set_margin_start(12)
+        self.text_entry.set_margin_end(12)
+        self.text_entry.set_margin_top(12)
+        self.text_entry.set_margin_bottom(12)
+        
+        self.text_entry.add_css_class("calc-entry")
+        self.text_entry.add_css_class("calc-display")
+
+        entry_key_controller = Gtk.EventControllerKey()
+        entry_key_controller.connect('key-pressed',
+                                     self._parent.keypress_cb)
+        self.text_entry.add_controller(entry_key_controller)
+        
+        vc1.append(self.text_entry)
         self.grid.attach(vc1, 0, 0, 7, 6)
 
-# Left part: buttons
+        # Buttons
         self.pad = Gtk.Grid()
         self.pad.set_column_homogeneous(True)
         self.pad.set_row_spacing(6)
         self.pad.set_column_spacing(6)
+        
         self.create_button_data()
         self.buttons = {}
+        
         for x, y, w, h, cap, bgcol, cb in self.button_data:
-            button = self.create_button(
-                _(cap), cb, self.col_white, bgcol, w, h)
+            button = self.create_button(cap, cb, bgcol)
             button.set_vexpand(True)
+            button.set_hexpand(True)
             self.buttons[cap] = button
             self.pad.attach(button, x, y, w, h)
+            
+        # Button container style
+        eb_pad = Gtk.Box()
+        eb_pad.add_css_class("calc-display")
+        eb_pad.append(self.pad)
+        
+        self.grid.attach(eb_pad, 0, 6, 7, 20)
 
-        eb = Gtk.EventBox()
-        eb.add(self.pad)
-        eb.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        self.grid.attach(eb, 0, 6, 7, 20)
-
-# Right part: container and equation button
+        # Right part: Filter Combo
         hc2 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        combo = ComboBox()
-        combo.append_item(0, _('All equations'))
-        combo.append_item(1, _('My equations'))
-        combo.append_item(2, _('Show variables'))
+        
+        combo = Gtk.ComboBoxText()
+        combo.append("all", _('All equations'))
+        combo.append("my", _('My equations'))
+        combo.append("var", _('Show variables'))
         combo.set_active(0)
         combo.connect('changed', self._history_filter_cb)
-        hc2.pack_start(combo, True, True, 0)
-        hc2.set_border_width(6)
+        
+        combo.set_hexpand(True)
+        hc2.append(combo)
+        hc2.set_margin_top(6) 
+        hc2.set_margin_bottom(6)
+        hc2.set_margin_start(6)
+        hc2.set_margin_end(6)
+        
         self.grid.attach(hc2, 7, 0, 4, 2)
 
-# Right part: last equation
+        # Right part: Last Equation TextView
         self.last_eq = Gtk.TextView()
         self.last_eq.set_editable(False)
         self.last_eq.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        self.last_eq.connect('realize', self._textview_realize_cb)
-        self.last_eq.modify_base(Gtk.StateType.NORMAL, Gdk.color_parse(
-                                 sugar3.profile.get_color().get_fill_color()))
-        self.last_eq.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse(
-                               sugar3.profile.get_color().get_stroke_color()))
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.LEFT, 4)
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.RIGHT, 4)
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.TOP, 4)
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.BOTTOM, 4)
-
-        xo_color = sugar3.profile.get_color()
-        bright = (
-            Gdk.color_parse(xo_color.get_fill_color()).red_float +
-            Gdk.color_parse(xo_color.get_fill_color()).green_float +
-            Gdk.color_parse(xo_color.get_fill_color()).blue_float) / 3.0
-        if bright < 0.5:
-            self.last_eq.modify_text(Gtk.StateType.NORMAL, self.col_white)
-        else:
-            self.last_eq.modify_text(Gtk.StateType.NORMAL, self.col_black)
-
+        self.last_eq.add_css_class("history-view")
+        self.last_eq.set_left_margin(4)
+        self.last_eq.set_right_margin(4)
+        self.last_eq.set_top_margin(4)
+        self.last_eq.set_bottom_margin(4)
+        
         self.grid.attach(self.last_eq, 7, 2, 4, 5)
 
-# Right part: history
+        # Right part: History ScrolledWindow
         scrolled_window = Gtk.ScrolledWindow()
-        scrolled_window.set_policy(Gtk.PolicyType.NEVER,
-                                   Gtk.PolicyType.AUTOMATIC)
-
-        self.history_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
-                                    spacing=4)
-        self.history_vbox.set_homogeneous(False)
-        self.history_vbox.set_border_width(0)
-
-        self.variable_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
-                                     spacing=4)
-        self.variable_vbox.set_homogeneous(False)
-        self.variable_vbox.set_border_width(0)
-
+        scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        
+        self.history_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        self.history_vbox.set_hexpand(True)
+        self.history_vbox.set_vexpand(True)
+        self.variable_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        self.variable_vbox.set_hexpand(True)
+        self.variable_vbox.set_vexpand(True)
+        
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        vbox.pack_start(self.history_vbox, True, True, 0)
-        vbox.pack_start(self.variable_vbox, True, True, 0)
-        scrolled_window.add_with_viewport(vbox)
+        vbox.append(self.history_vbox)
+        vbox.append(self.variable_vbox)
+        
+        scrolled_window.set_child(vbox)
         self.grid.attach(scrolled_window, 7, 7, 4, 19)
-
-        Gdk.Screen.get_default().connect('size-changed',
-                                         self._configure_cb)
-
-    def _configure_cb(self, event):
-        # Maybe redo layout
-        self._toolbar_box.toolbar.remove(self._stop)
-        self._toolbar_box.toolbar.remove(self._stop_separator)
-        self._misc_toolbar.update_layout()
-        self._toolbar_box.toolbar.insert(self._stop_separator, -1)
-        self._toolbar_box.toolbar.insert(self._stop, -1)
 
     def show_it(self):
         """Show the dialog."""
         self._parent.set_canvas(self.grid)
-        self._parent.show_all()
         self.show_history()
         self.text_entry.grab_focus()
+        if hasattr(self._parent, 'present'):
+            self._parent.present()
 
     def showing_history(self):
-        """Return whether we're currently showing the history (or otherwise
-        the list of variables)."""
+        """Return whether we're currently showing the history."""
         return self._showing_history
 
     def show_history(self):
         """Show the history VBox."""
         self._showing_history = True
-        self.variable_vbox.hide()
-        self.history_vbox.show()
+        self.variable_vbox.set_visible(False)
+        self.history_vbox.set_visible(True)
 
-    def toggle_select_graph(self, widget, host=None):
+    def toggle_select_graph(self, widget):
+
         # if we have a graph already selected, we must deselect it first
         if self.graph_selected and self.graph_selected != widget:
             self.toggle_select_graph(self.graph_selected)
 
         if not self.graph_selected:
-            widget.set_visible_window(True)
-            widget.set_above_child(True)
             self.graph_selected = widget
-            white = Gdk.color_parse('white')
-            widget.modify_bg(Gtk.StateType.NORMAL, white)
+            
+            # Highlight with CSS
+            widget.add_css_class("selected-graph") 
+            
         else:
-            widget.set_visible_window(False)
-            self.graph_selected = False
+            widget.remove_css_class("selected-graph")
+            self.graph_selected = None
 
     def add_equation(self, textview, own, prepend=False):
         """Add a Gtk.TextView of an equation to the history_vbox."""
 
-        GraphEventBox = None
-        if isinstance(textview, Gtk.Image):
-            # Add the image inside the eventBox
-            GraphEventBox = Gtk.EventBox()
-            GraphEventBox.add(textview)
-            GraphEventBox.set_visible_window(False)
-            GraphEventBox.connect(
-                'button_press_event', self.toggle_select_graph)
-            GraphEventBox.show()
+        container = None
+        if isinstance(textview, (Gtk.Image, Gtk.Picture)):
+            container = Gtk.Box()
+            container.append(textview)
+            
+            click_gesture = Gtk.GestureClick()
+            click_gesture.set_button(1)
+            click_gesture.connect("pressed", lambda g, n, x, y: self.toggle_select_graph(container))
+            container.add_controller(click_gesture)
+        
+        widget_to_add = container if container else textview
 
         if prepend:
-            if GraphEventBox:
-                self.history_vbox.pack_start(GraphEventBox, False, True, 0)
-                self.history_vbox.reorder_child(GraphEventBox, 0)
-            else:
-                self.history_vbox.pack_start(textview, False, True, 0)
-                self.history_vbox.reorder_child(textview, 0)
+            self.history_vbox.prepend(widget_to_add)
         else:
-            if GraphEventBox:
-                self.history_vbox.pack_end(GraphEventBox, False, True)
-            else:
-                self.history_vbox.pack_end(textview, False, True)
+            self.history_vbox.append(widget_to_add)
 
         if own:
-            if GraphEventBox:
-                self._own_equations.append(GraphEventBox)
-                GraphEventBox.get_child().show()
-            else:
-                self._own_equations.append(textview)
-                textview.show()
+            self._own_equations.append(widget_to_add)
+            widget_to_add.set_visible(True)
         else:
             if self._showing_all_history:
-                if GraphEventBox:
-                    self._other_equations.append(GraphEventBox)
-                    GraphEventBox.get_child().show()
-                else:
-                    self._other_equations.append(textview)
-                    textview.show()
+                self._other_equations.append(widget_to_add)
+                widget_to_add.set_visible(True)
+            else:
+                self._other_equations.append(widget_to_add)
+                widget_to_add.set_visible(False)
 
     def show_all_history(self):
         """Show both owned and other equations."""
         self._showing_all_history = True
         for key in self._other_equations:
-            if isinstance(key, Gtk.EventBox):
-                key.get_child().show()
-            else:
-                key.show()
+            key.set_visible(True)
 
     def show_own_history(self):
         """Show only owned equations."""
         self._showing_all_history = False
         for key in self._other_equations:
-            if isinstance(key, Gtk.EventBox):
-                key.get_child().hide()
-            else:
-                key.hide()
+            key.set_visible(False)
 
     def add_variable(self, varname, textview):
         """Add a Gtk.TextView of a variable to the variable_vbox."""
@@ -426,39 +385,53 @@ class CalcLayout:
             del self._var_textviews[varname]
 
         self._var_textviews[varname] = textview
-        self.variable_vbox.pack_start(textview, False, True, 0)
+        self.variable_vbox.append(textview)
 
         # Reorder textviews for a sorted list
         names = list(self._var_textviews.keys())
         names.sort()
-        for i in range(len(names)):
-            self.variable_vbox.reorder_child(self._var_textviews[names[i]], i)
+        
+        prev = None
+        for name in names:
+            child = self._var_textviews[name]
+            self.variable_vbox.reorder_child_after(child, prev)
+            prev = child
 
-        textview.show()
 
     def show_variables(self):
         """Show the variables VBox."""
         self._showing_history = False
-        self.history_vbox.hide()
-        self.variable_vbox.show()
+        self.history_vbox.set_visible(False)
+        self.variable_vbox.set_visible(True)
 
-    def create_button(self, cap, cb, fgcol, bgcol, width, height):
+    def create_button(self, cap, cb, bgcol):
         """Create a button that is set up properly."""
-        button = Gtk.Button(_(cap))
-        self.modify_button_appearance(button, fgcol, bgcol, width, height)
+        button = Gtk.Button(label=cap)
+        self.modify_button_appearance(button, bgcol)
+        
+        # Attach an event controller to intercept keystrokes
+        key_ctrl = Gtk.EventControllerKey()
+        key_ctrl.connect('key-pressed', self._parent.keypress_cb)
+        button.add_controller(key_ctrl)
+        
         button.connect("clicked", cb)
-        button.connect("key_press_event", self._parent.ignore_key_cb)
         return button
 
-    def modify_button_appearance(self, button, fgcol, bgcol, width, height):
-        """Modify button style."""
-        width = 50 * width
-        button.get_child().set_size_request(width, height)
-        button.get_child().modify_font(self.button_font)
-        button.get_child().modify_fg(Gtk.StateType.NORMAL, fgcol)
-        button.modify_bg(Gtk.StateType.NORMAL, bgcol)
-        button.modify_bg(Gtk.StateType.PRELIGHT, bgcol)
+    def modify_button_appearance(self, button, bgcol):
+        button.add_css_class("calc-button")
 
+        # Map color to semantic CSS class
+        color_class_map = {
+            id(self.col_white): "calc-white-btn",
+            id(self.col_gray1): "calc-action-btn",
+            id(self.col_gray2): "calc-numpad-btn",
+            id(self.col_gray3): "calc-operator-btn",
+            id(self.col_red): "calc-danger-btn",
+        }
+        css_class = color_class_map.get(id(bgcol))
+        if css_class:
+            button.add_css_class(css_class)
+        
     def _history_filter_cb(self, combo):
         selection = combo.get_active()
         if selection == 0:
@@ -469,9 +442,3 @@ class CalcLayout:
             self.show_own_history()
         elif selection == 2:
             self.show_variables()
-
-    def _textview_realize_cb(self, widget):
-        '''Change textview properties once window is created.'''
-        win = widget.get_window(Gtk.TextWindowType.TEXT)
-        win.set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
-        return False

--- a/layout.py
+++ b/layout.py
@@ -135,7 +135,14 @@ class CalcLayout:
 # Toolbar
         self._toolbar_box = ToolbarBox()
         
-        activity_button = ActivityToolbarButton(self._parent)
+        # Pass the activity icon explicitly (works around a GTK4 toolkit issue where it defaults to activity-journal)
+        icon_name = "activity-calculate"
+        if hasattr(self._parent, 'metadata') and self._parent.metadata:
+            icon_name = self._parent.metadata.get('icon', 'activity-calculate')
+            if icon_name == 'calculate':
+                icon_name = 'activity-calculate'
+        
+        activity_button = ActivityToolbarButton(self._parent, icon_name=icon_name)
         self._toolbar_box.get_toolbar().append(activity_button)
 
         def append_toolbar(icon_name, label, page):

--- a/main.py
+++ b/main.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import gi
+import cairo
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk, Gdk
+
+gi.require_foreign("cairo")
+
+# Set up standalone environment
+os.environ.setdefault("SUGAR_BUNDLE_ID", "org.sugarlabs.Calculate")
+os.environ.setdefault("SUGAR_BUNDLE_NAME", "Calculate")
+os.environ.setdefault("SUGAR_BUNDLE_PATH", os.getcwd())
+os.environ.setdefault("SUGAR_ACTIVITY_ROOT", os.path.expanduser("~/.sugar/default/org.sugarlabs.Calculate"))
+
+activity_root = os.environ["SUGAR_ACTIVITY_ROOT"]
+for subdir in ["tmp", "instance", "data"]:
+    os.makedirs(os.path.join(activity_root, subdir), exist_ok=True)
+
+from sugar4.activity.activityhandle import ActivityHandle
+from calculate import Calculate
+
+def main():
+    def on_activate(app):
+        icon_theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+        icon_theme.add_search_path(os.path.join(os.getcwd(), "icons"))
+
+        # Load the CSS Provider
+        css_provider = Gtk.CssProvider()
+        css_path = os.path.join(os.getcwd(), "activity.css")
+        if os.path.exists(css_path):
+            css_provider.load_from_path(css_path)
+            Gtk.StyleContext.add_provider_for_display(
+                Gdk.Display.get_default(),
+                css_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
+
+        handle = ActivityHandle(
+            activity_id="calculate-local",
+            object_id="calculate-local"
+        )
+        try:
+            win = Calculate(handle)
+            app.add_window(win)
+            win.present()
+        except Exception as e:
+            print("Failed to launch activity: %s" % e, file=sys.stderr)
+            app.quit()
+
+    app = Gtk.Application(application_id="org.sugarlabs.Calculate.local")
+    app.connect("activate", on_activate)
+    return app.run(sys.argv)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plotlib.py
+++ b/plotlib.py
@@ -151,8 +151,8 @@ class CustomPlot(_PlotBase):
         self.svg_data += '" />\n'
 
     def add_text(self, c, text, rotate=0):
-        if isinstance(text, str):
-            text = text.encode('utf-8')
+        if isinstance(text, bytes):
+            text = text.decode('utf-8')
         c = self.rcoords_to_coords(c)
 
         self.svg_data += '<text x="%f" y="%f"' % (c[0], c[1])
@@ -227,10 +227,10 @@ class CustomPlot(_PlotBase):
         min_x = min(x_coords)
 
         # X axis
-        interval = len(val) / (NOL - 1)
+        interval = max(1, len(val) // (NOL - 1))
         self.plot_line((0.11, 0.89), (0.92, 0.89), "black")
         if max_x != min_x:
-            self.add_text((0.11 + min_x + F * 0, 0.93), format_float(min_x))
+            self.add_text((0.11 + F * 0, 0.93), format_float(min_x))
             plot_index = interval
             while plot_index <= len(val) - interval:
                 self.add_text((0.11 + F * abs(x_coords[plot_index] - min_x) /
@@ -297,6 +297,7 @@ class MPLPlot(_PlotBase):
 
         data = StringIO()
         fig.savefig(data)
+        pylab.close(fig)
         return data.getvalue()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
-from sugar3.activity import bundlebuilder
+from sugar4.activity import bundlebuilder
 bundlebuilder.start()

--- a/shareable_activity.py
+++ b/shareable_activity.py
@@ -1,13 +1,15 @@
 import gi
 
 import dbus
+import dbus.service
+
 gi.require_version('TelepathyGLib', '0.12')
 from gi.repository import GObject
 from gi.repository import TelepathyGLib
 
-from sugar3.activity import activity
-from sugar3.presence import presenceservice
-from sugar3.presence.sugartubeconn import SugarTubeConnection
+from sugar4.activity import activity
+from sugar4.presence import presenceservice
+from sugar4.presence.sugartubeconn import SugarTubeConnection
 
 import logging
 _logger = logging.getLogger('ShareableActivity')
@@ -47,7 +49,7 @@ class ShareableActivity(activity.Activity):
             service_path
         '''
 
-        activity.Activity.__init__(self, handle, *args, **kwargs)
+        activity.Activity.__init__(self, handle, *args, **kwargs, application=None)
 
         self._sync_hid = None
         self._message_cbs = {}

--- a/svgimage.py
+++ b/svgimage.py
@@ -20,36 +20,64 @@
 import logging
 _logger = logging.getLogger('SVGImage')
 
-from gi.repository import Gtk
-from gi.repository import Rsvg
+from gi.repository import Gtk, Gdk, GdkPixbuf
 
 
 class SVGImage:
 
     def __init__(self, fn=None, data=None):
+        self._svg_data = None
         if fn is not None:
             self.load(fn)
         elif data is not None:
             self.load_data(data)
 
     def get_image(self):
-        return self._image
+        return getattr(self, '_image', None)
 
     def get_svg_data(self):
         return self._svg_data
-
+    
     def render_svg(self):
-        self._handle = Rsvg.Handle.new_from_data(self._svg_data)
-        self._pixbuf = self._handle.get_pixbuf()
-        self._image = Gtk.Image()
-        self._image.set_from_pixbuf(self._pixbuf)
-        self._image.set_alignment(0.5, 0)
+        b_data = self._svg_data.encode('utf-8') if isinstance(self._svg_data, str) else self._svg_data
+        
+        pixbuf = None
+        
+        try:
+            loader = GdkPixbuf.PixbufLoader.new_with_type('svg')
+            loader.write(b_data)
+            loader.close()
+            pixbuf = loader.get_pixbuf()
+        except Exception as e:
+            _logger.error("Failed to load SVG with PixbufLoader: %s", e)
+        
+        if not pixbuf:
+            _logger.error("Could not render SVG to pixbuf.")
+            return None
+
+        _logger.debug("SVG rendered to pixbuf: %dx%d",
+                       pixbuf.get_width(), pixbuf.get_height())
+
+        texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+        
+        self._image = Gtk.Picture()
+        self._image.set_paintable(texture)
+
+        self._image.set_size_request(pixbuf.get_width(),
+                                     pixbuf.get_height())
+        try:
+            self._image.set_can_shrink(False)
+        except AttributeError:
+            pass
+        
+        self._image.set_halign(Gtk.Align.CENTER)
+        self._image.set_valign(Gtk.Align.START)
+        
         return self._image
 
     def load(self, fn):
-        f = open(fn, 'rb')
-        self._svg_data = f.read()
-        f.close()
+        with open(fn, 'rb') as f:
+            self._svg_data = f.read()
         return self.render_svg()
 
     def load_data(self, svgdat):

--- a/toolbars.py
+++ b/toolbars.py
@@ -2,16 +2,16 @@
 # toolbars.py, see CalcActivity.py for info
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
 from mathlib import MathLib
 
-from sugar3.graphics.palette import Palette
-from sugar3.graphics.menuitem import MenuItem
-from sugar3.graphics.toolbutton import ToolButton
-from sugar3.graphics.toggletoolbutton import ToggleToolButton
-from sugar3.graphics.style import GRID_CELL_SIZE
+from sugar4.graphics.palette import Palette
+from sugar4.graphics.menuitem import MenuItem
+from sugar4.graphics.toolbutton import ToolButton
+from sugar4.graphics.toggletoolbutton import ToggleToolButton
+
 
 import logging
 _logger = logging.getLogger('calc-activity')
@@ -23,9 +23,8 @@ def _icon_exists(name):
     if name == '':
         return False
 
-    theme = Gtk.IconTheme.get_default()
-    info = theme.lookup_icon(name, 0, 0)
-    if info:
+    theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+    if theme.has_icon(name):
         return True
 
     return False
@@ -35,6 +34,8 @@ class IconToolButton(ToolButton):
 
     def __init__(self, icon_name, text, cb, help_cb=None, alt_html=''):
         ToolButton.__init__(self)
+        self.add_css_class("calc-button")
+        self.add_css_class("calc-operator-btn")
 
         if _icon_exists(icon_name):
             self.props.icon_name = icon_name
@@ -43,9 +44,9 @@ class IconToolButton(ToolButton):
                 alt_html = icon_name
 
             label = Gtk.Label()
+            label.add_css_class("toolbar-fallback-label")
             label.set_markup(alt_html)
-            label.show()
-            self.set_label_widget(label)
+            self.set_child(label)
 
         self.create_palette(text, help_cb)
 
@@ -57,7 +58,6 @@ class IconToolButton(ToolButton):
         if help_cb is not None:
             item = MenuItem(_('Help'), 'action-help')
             item.connect('activate', help_cb)
-            item.show()
             p.menu.append(item)
 
         self.set_palette(p)
@@ -67,13 +67,15 @@ class IconToggleToolButton(ToggleToolButton):
 
     def __init__(self, items, cb, desc):
         ToggleToolButton.__init__(self)
+        self.add_css_class("calc-button")
+        self.add_css_class("calc-operator-btn")
         self.items = items
         if 'icon' in items[0] and _icon_exists(items[0]['icon']):
             self.props.icon_name = items[0]['icon']
         elif 'html' in items[0]:
             self.set_label(items[0]['html'])
-#        self.set_tooltip(items[0][1])
-        self.set_tooltip(desc)
+#        self.set_tooltip_text(items[0][1])
+        self.set_tooltip_text(desc)
         self.selected = 0
         self.connect('clicked', self.toggle_button)
         self.callback = cb
@@ -86,7 +88,7 @@ class IconToggleToolButton(ToggleToolButton):
         elif 'html' in but:
             _logger.info('Setting html: %s', but['html'])
             self.set_label(but['html'])
-#        self.set_tooltip(but[1])
+#        self.set_tooltip_text(but[1])
         if self.callback is not None:
             if 'html' in but:
                 self.callback(but['html'])
@@ -94,14 +96,16 @@ class IconToggleToolButton(ToggleToolButton):
                 self.callback(but)
 
 
-class TextToggleToolButton(Gtk.ToggleToolButton):
+class TextToggleToolButton(Gtk.ToggleButton):
 
     def __init__(self, items, cb, desc, index=False):
-        Gtk.ToggleToolButton.__init__(self)
+        Gtk.ToggleButton.__init__(self)
+        self.add_css_class("calc-button")
+        self.add_css_class("calc-operator-btn")
         self.items = items
         self.set_label(items[0])
         self.selected = 0
-        self.connect('clicked', self.toggle_button)
+        self.connect('toggled', self.toggle_button)
         self.callback = cb
         self.index = index
         self.set_tooltip_text(desc)
@@ -117,23 +121,22 @@ class TextToggleToolButton(Gtk.ToggleToolButton):
                 self.callback(but)
 
 
-class LineSeparator(Gtk.SeparatorToolItem):
+class LineSeparator(Gtk.Separator):
 
     def __init__(self):
-        Gtk.SeparatorToolItem.__init__(self)
-        self.set_draw(True)
+        Gtk.Separator.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
 
-class EditToolbar(Gtk.Toolbar):
+class EditToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
         copy_tool = ToolButton('edit-copy')
-        copy_tool.set_tooltip(_('Copy'))
+        copy_tool.set_tooltip_text(_('Copy'))
         copy_tool.set_accelerator(_('<ctrl>c'))
         copy_tool.connect('clicked', lambda x: calc.text_copy())
-        self.insert(copy_tool, -1)
+        self.append(copy_tool)
 
         menu_item = MenuItem(_('Cut'))
 
@@ -143,189 +146,184 @@ class EditToolbar(Gtk.Toolbar):
             pass
 
         menu_item.connect('activate', lambda x: calc.text_cut())
-        menu_item.show()
-        copy_tool.get_palette().menu.append(menu_item)
+        
+        palette = copy_tool.get_palette()
+        if palette is None:
+            # Cut lives in Copy's palette as a secondary action
+            palette = Palette(_('Copy'))
+            copy_tool.set_palette(palette)
+        palette.menu.append(menu_item)
 
-        self.insert(IconToolButton('edit-paste', _('Paste'),
+        self.append(IconToolButton('edit-paste', _('Paste'),
                                    lambda x: calc.text_paste(),
-                                   alt_html='Paste'), -1)
-
-        self.show_all()
+                                   alt_html='Paste'))
 
 
-class AlgebraToolbar(Gtk.Toolbar):
+class AlgebraToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
-        self.insert(IconToolButton('algebra-square', _('Square'),
+        self.append(IconToolButton('algebra-square', _('Square'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_OP_POST, '**2'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(square)'),
-                                   alt_html='x<sup>2</sup>'), -1)
+                                   alt_html='x<sup>2</sup>'))
 
-        self.insert(IconToolButton('algebra-sqrt', _('Square root'),
+        self.append(IconToolButton('algebra-sqrt', _('Square root'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'sqrt'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(sqrt)'),
-                                   alt_html='√x'), -1)
+                                   alt_html='√x'))
 
-        self.insert(IconToolButton('algebra-xinv', _('Inverse'),
+        self.append(IconToolButton('algebra-xinv', _('Inverse'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_OP_POST, '**-1'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(inv)'),
-                                   alt_html='x<sup>-1</sup>'), -1)
+                                   alt_html='x<sup>-1</sup>'))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton('algebra-exp', _('e to the power x'),
+        self.append(IconToolButton('algebra-exp', _('e to the power x'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'exp'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(exp)'),
-                                   alt_html='e<sup>x</sup>'), -1)
+                                   alt_html='e<sup>x</sup>'))
 
-        self.insert(IconToolButton('algebra-xpowy', _('x to the power y'),
+        self.append(IconToolButton('algebra-xpowy', _('x to the power y'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'pow'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(pow)'),
-                                   alt_html='x<sup>y</sup>'), -1)
+                                   alt_html='x<sup>y</sup>'))
 
-        self.insert(IconToolButton('algebra-ln', _('Natural logarithm'),
+        self.append(IconToolButton('algebra-ln', _('Natural logarithm'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'ln'),
                                    lambda x: calc.button_pressed(
-                                       calc.TYPE_TEXT, 'help(ln)')), -1)
+                                       calc.TYPE_TEXT, 'help(ln)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'algebra-fac', _('Factorial'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'factorial'),
             lambda x: calc.button_pressed(calc.TYPE_TEXT,
-                                          'help(factorial)')), -1)
-
-        self.show_all()
+                                          'help(factorial)')))
 
 
-class TrigonometryToolbar(Gtk.Toolbar):
+class TrigonometryToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-sin', _('Sine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'sin'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sin)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sin)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-cos', _('Cosine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'cos'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cos)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cos)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-tan', _('Tangent'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'tan'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tan)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tan)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-asin', _('Arc sine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'asin'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(asin)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(asin)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-acos', _('Arc cosine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'acos'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(acos)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(acos)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-atan', _('Arc tangent'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'atan'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(atan)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(atan)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-sinh', _('Hyperbolic sine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'sinh'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sinh)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sinh)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-cosh', _('Hyperbolic cosine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'cosh'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cosh)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cosh)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-tanh', _('Hyperbolic tangent'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'tanh'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tanh)')), -1)
-
-        self.show_all()
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tanh)')))
 
 
-class BooleanToolbar(Gtk.Toolbar):
+class BooleanToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-and', _('Logical and'),
             lambda x: calc.button_pressed(calc.TYPE_OP_POST, '&'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(And)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(And)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-or', _('Logical or'),
             lambda x: calc.button_pressed(calc.TYPE_OP_POST, '|'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(Or)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(Or)')))
 
-#        self.insert(IconToolButton('boolean-xor', _('Logical xor'),
+#        self.append(IconToolButton('boolean-xor', _('Logical xor'),
 #            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '^'),
-#            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(xor)')), -1)
+#            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(xor)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-eq', _('Equals'),
-            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '==')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '==')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-neq', _('Not equals'),
-            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '!=')), -1)
-
-        self.show_all()
+            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '!=')))
 
 
-class MiscToolbar(Gtk.Toolbar):
+class MiscToolbar(Gtk.Box):
 
-    def __init__(self, calc, target_toolbar=None):
-        self._target_toolbar = target_toolbar
+    def __init__(self, calc):
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
-        Gtk.Toolbar.__init__(self)
-
-        self.insert(IconToolButton('constants-pi', _('Pi'),
+        self.append(IconToolButton('constants-pi', _('Pi'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'pi'),
-                                   alt_html='π'), -1)
+                                   alt_html='π'))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'constants-e', _('e'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'e')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'e')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'constants-eulersconstant', _('γ'),
             lambda x: calc.button_pressed(calc.TYPE_TEXT,
-                                          '0.577215664901533')), -1)
+                                          '0.577215664901533')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'constants-goldenratio', _('φ'),
             lambda x: calc.button_pressed(calc.TYPE_TEXT,
-                                          '1.618033988749895')), -1)
+                                          '1.618033988749895')))
 
         self._line_separator1 = LineSeparator()
         self._line_separator2 = LineSeparator()
@@ -378,34 +376,11 @@ class MiscToolbar(Gtk.Toolbar):
             lambda x: self.update_int_base(x, calc),
             _('Integer formatting base'))
 
-        self.update_layout()
-
-        self.show_all()
-
-    def update_layout(self):
-        if Gdk.Screen.width() < 14 * GRID_CELL_SIZE or \
-                self._target_toolbar is None:
-            target_toolbar = self
-            if self._target_toolbar is not None:
-                self._remove_buttons(self._target_toolbar)
-        else:
-            target_toolbar = self._target_toolbar
-
         for item in [self._line_separator1, self._plot_button,
                      self._line_separator2, self._angle_button,
                      self._format_button, self._digits_button,
                      self._base_button]:
-            if item.get_parent():
-                item.get_parent().remove(item)
-            target_toolbar.insert(item, -1)
-
-    def _remove_buttons(self, toolbar):
-        for item in [self._plot_button, self._line_separator1,
-                     self._line_separator2, self._angle_button,
-                     self._format_button, self._digits_button,
-                     self._base_button]:
-            if item.get_parent() == toolbar:
-                toolbar.remove(item)
+            self.append(item)
 
     def update_angle_type(self, text, calc):
         var = calc.parser.get_var('angle_scaling')

--- a/toolbars.py
+++ b/toolbars.py
@@ -34,8 +34,6 @@ class IconToolButton(ToolButton):
 
     def __init__(self, icon_name, text, cb, help_cb=None, alt_html=''):
         ToolButton.__init__(self)
-        self.add_css_class("calc-button")
-        self.add_css_class("calc-operator-btn")
 
         if _icon_exists(icon_name):
             self.props.icon_name = icon_name
@@ -67,8 +65,6 @@ class IconToggleToolButton(ToggleToolButton):
 
     def __init__(self, items, cb, desc):
         ToggleToolButton.__init__(self)
-        self.add_css_class("calc-button")
-        self.add_css_class("calc-operator-btn")
         self.items = items
         if 'icon' in items[0] and _icon_exists(items[0]['icon']):
             self.props.icon_name = items[0]['icon']
@@ -100,8 +96,6 @@ class TextToggleToolButton(Gtk.ToggleButton):
 
     def __init__(self, items, cb, desc, index=False):
         Gtk.ToggleButton.__init__(self)
-        self.add_css_class("calc-button")
-        self.add_css_class("calc-operator-btn")
         self.items = items
         self.set_label(items[0])
         self.selected = 0


### PR DESCRIPTION
This PR ports the Calculate activity UI from GTK3 to GTK4/Sugar4. The math engine and parser remain unchanged; only the UI layer and event handling were updated.

## What changed
* Replaced deprecated `Gtk.Toolbar` subclasses and packing APIs with `Gtk.Grid` and `Gtk.Box`
* Removed legacy styling calls (`modify_bg`, `modify_font`, `modify_base`) and switched to semantic CSS classes: `calc-button`, `calc-numpad-btn`, `calc-operator-btn`, and `calc-action-btn`
* Retained per-user XoColor styling for equation history and variable views using `sugar_style.apply_css_to_widget()`
* Reworked the toolbar to use Sugar4 `ToolbarBox` / `ToolbarButton`
* Updated `toolbars.py` to use `set_child()` for text fallback when SVG icons are missing
* Migrated key handling to `Gtk.EventControllerKey` (and explicitly set the `CAPTURE` phase to prevent input widgets from swallowing global shortcuts like `Enter` and arrow keys)
* Added `Gtk.StateFlags.FOCUS_WITHIN` focus awareness to the keystroke interceptor so users can smoothly use backspace while typing inside the label entry field.
* Migrated deprecated `button-press-event` handlers on history items to proper `Gtk.GestureClick` controllers (restricted to button 1 for left-clicks).
* Replaced hardcoded GTK3 key codes and the limited `IDENTIFIER_CHARS` fallback with `Gdk.keyval_to_unicode` to robustly handle numpad digits and international character input.
* Cleaned up a misleading layout fallback that incorrectly displayed `0` when evaluating expressions that returned no output.
* Updated clipboard handling to GTK4’s async clipboard API, including restoring graph copying using `Gdk.Texture` and adding `_on_paste_text_received` callbacks.
* Fixed a layout collapse issue where SVG graphs in `Gtk.Picture` were rendering at `0x0` size in GTK4 Box containers (`svgimage.py`) and updated layout history to properly handle `Gtk.Picture` widgets (`layout.py`)
* Resolved a memory leak in the fallback Matplotlib backend by explicitly closing figure objects (`plotlib.py`)
* Fixed an integer division crash (`//`) and Python 3 string safety issues (`base64.decode`) in the SVG graph renderer (`plotlib.py` and `calculate.py`).
* Added `main.py` for standalone local testing
* Fixed Python 3.14+ compatibility in the math engine by migrating deprecated `ast.Num`/`ast.Str` nodes to `ast.Constant` (`astparser.py`).
* Fixed a `TypeError` crash in network collaboration (`message_received`) by explicitly passing `ml=self.ml` to the `Equation` constructor.
* Guarded against `None` and empty results in `create_history_object` by wrapping `ml.format_number` in a try/except and normalizing falsy results to an empty string.


## Notes on standalone testing
A couple of visual issues are expected when running via `main.py` outside Sugar:
* Buttons use the default GTK4 look because `sugar-artwork` does not yet provide the full GTK4 theme styling
* Some toolbar icons may be missing outside Sugar and fall back to text; on the dark toolbar, those fallbacks can appear faint or mostly empty

These are standalone-testing limitations and should not affect behavior inside the Sugar desktop.

### Testing Environment
* **OS:** Fedora 44 ISO (Sugar Build)
* **Environment:** Oracle VirtualBox
* **Toolkit:** `sugar-toolkit-gtk4` 

### How to Test This PR

Since the core GTK4 Sugar shell (Jarabe) is currently undergoing major upstream environment updates (moving towards Debian 13), you can easily test this activity port completely isolated from the main shell.

**1. Run locally without the Sugar Shell**
From the root of the `calculate-activity` directory, simply run the local execution wrapper:

```bash
GSK_RENDERER=cairo python3 main.py
```


https://github.com/user-attachments/assets/3484341f-e406-4897-9d5f-7f49724c89fe


