### PR TITLE
Port To Gtk4

### DIFF
--- a/calculate.py
+++ b/calculate.py
@@ -26,13 +26,13 @@ import logging
 _logger = logging.getLogger('Calculate')
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
 import base64
 
-import sugar3.profile
-from sugar3.graphics.xocolor import XoColor
+import sugar4.profile
+from sugar4.graphics.xocolor import XoColor
 
 from shareable_activity import ShareableActivity
 from layout import CalcLayout
@@ -64,8 +64,7 @@ def findchar(text, chars, ofs=0):
 
 def _textview_realize_cb(widget):
     '''Change textview properties once window is created.'''
-    win = widget.get_window(Gtk.TextWindowType.TEXT)
-    win.set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
+    widget.set_cursor(Gdk.Cursor.new_from_name('pointer', None))
     return False
 
 
@@ -244,16 +243,31 @@ class Equation:
             return self.result.get_image()
 
         w = Gtk.TextView()
-        w.modify_base(
-            Gtk.StateType.NORMAL, Gdk.color_parse(self.color.get_fill_color()))
-        w.modify_bg(
-            Gtk.StateType.NORMAL,
-            Gdk.color_parse(self.color.get_stroke_color()))
+        
+        # Use CSS for styling in GTK4
+        css_provider = Gtk.CssProvider()
+        fill_color = self.color.get_fill_color()
+        stroke_color = self.color.get_stroke_color()
+        css = f"""
+        textview {{
+            background-color: {fill_color};
+        }}
+        textview text {{
+            background-color: {fill_color};
+            color: {stroke_color};
+        }}
+        """
+        css_provider.load_from_data(css.encode())
+        w.get_style_context().add_provider(
+            css_provider, 
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+        
         w.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        w.set_border_window_size(Gtk.TextWindowType.LEFT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.RIGHT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.TOP, 4)
-        w.set_border_window_size(Gtk.TextWindowType.BOTTOM, 4)
+        w.set_left_margin(4)
+        w.set_right_margin(4)
+        w.set_top_margin(4)
+        w.set_bottom_margin(4)
         w.connect('realize', _textview_realize_cb)
         buf = w.get_buffer()
 
@@ -261,11 +275,10 @@ class Equation:
         tagsmallnarrow = buf.create_tag(font=CalcLayout.FONT_SMALL_NARROW)
         tagbig = buf.create_tag(font=CalcLayout.FONT_BIG,
                                 justification=Gtk.Justification.RIGHT)
-        # TODO Fix for old Sugar 0.82 builds, red_float not available
-        bright = (
-            Gdk.color_parse(self.color.get_fill_color()).red_float +
-            Gdk.color_parse(self.color.get_fill_color()).green_float +
-            Gdk.color_parse(self.color.get_fill_color()).blue_float) / 3.0
+        # Calculate brightness to determine text color
+        rgba = Gdk.RGBA()
+        rgba.parse(self.color.get_fill_color())
+        bright = (rgba.red + rgba.green + rgba.blue) / 3.0
         if bright < 0.5:
             col = 'white'
         else:
@@ -374,7 +387,8 @@ class Calculate(ShareableActivity):
         self.KEYMAP['divide'] = self.ml.div_sym
         self.KEYMAP['equal'] = self.ml.equ_sym
 
-        self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        display = Gdk.Display.get_default()
+        self.clipboard = display.get_clipboard()
         self.select_reason = self.SELECT_SELECT
         self.buffer = ""
         self.showing_version = 0
@@ -382,9 +396,14 @@ class Calculate(ShareableActivity):
         self.ans_inserted = False
         self.show_vars = False
 
-        self.connect("key_press_event", self.keypress_cb)
+        controller = Gtk.EventControllerKey()
+        controller.connect("key-pressed", self.keypress_cb)
+        self.add_controller(controller)
         self.connect("destroy", self.cleanup_cb)
-        self.color = sugar3.profile.get_color()
+        self.color = sugar4.profile.get_color()
+
+        # Set a default window size for proper display
+        self.set_default_size(1200, 900)
 
         self.layout = CalcLayout(self)
         self.label_entry = self.layout.label_entry
@@ -399,7 +418,7 @@ class Calculate(ShareableActivity):
 
         self.parser.log_debug_info()
 
-    def ignore_key_cb(self, widget, event):
+    def ignore_key_cb(self, controller, keyval, keycode, state):
         return True
 
     def cleanup_cb(self, arg):
@@ -427,14 +446,21 @@ class Calculate(ShareableActivity):
     def set_last_equation(self, eqn):
         """Set the 'last equation' TextView."""
 
-        if self.last_eq_sig is not None:
-            self.layout.last_eq.disconnect(self.last_eq_sig)
-            self.last_eq_sig = None
+        if not hasattr(self, "_last_eq_gesture"):
+            self._last_eq_gesture = Gtk.GestureClick()
+            self._last_eq_gesture.connect(
+                "pressed",
+                lambda g, n, x, y: (
+                    self.equation_pressed_cb(self._last_eqn_for_click)
+                    if self._last_eqn_for_click is not None else None
+                ),
+            )
+            self.layout.last_eq.add_controller(self._last_eq_gesture)
 
         if not isinstance(eqn.result, ParserError):
-            self.last_eq_sig = self.layout.last_eq.connect(
-                'button-press-event',
-                lambda a1, a2, e: self.equation_pressed_cb(e), eqn)
+            self._last_eqn_for_click = eqn
+        else:
+            self._last_eqn_for_click = None
 
         self.layout.last_eq.set_buffer(eqn.create_lasteq_textbuf())
 
@@ -490,8 +516,13 @@ class Calculate(ShareableActivity):
 
         own = (eq.owner == self.get_owner_id())
         w = eq.create_history_object()
-        w.connect('button-press-event', lambda w,
-                  e: self.equation_pressed_cb(eq))
+        if isinstance(w, Gtk.TextView):
+            gesture = Gtk.GestureClick()
+            gesture.connect(
+                "pressed",
+                lambda g, n, x, y, _eq=eq: self.equation_pressed_cb(_eq),
+            )
+            w.add_controller(gesture)
         if drawlasteq:
             self.set_last_equation(eq)
 
@@ -576,28 +607,46 @@ class Calculate(ShareableActivity):
         if name in reserved:
             return None
         w = Gtk.TextView()
-        w.modify_base(
-            Gtk.StateType.NORMAL, Gdk.color_parse(self.color.get_fill_color()))
-        w.modify_bg(
-            Gtk.StateType.NORMAL,
-            Gdk.color_parse(self.color.get_stroke_color()))
+        
+        # Use CSS for styling in GTK4
+        css_provider = Gtk.CssProvider()
+        fill_color = self.color.get_fill_color()
+        stroke_color = self.color.get_stroke_color()
+        css = f"""
+        textview {{
+            background-color: {fill_color};
+        }}
+        textview text {{
+            background-color: {fill_color};
+            color: {stroke_color};
+        }}
+        """
+        css_provider.load_from_data(css.encode())
+        w.get_style_context().add_provider(
+            css_provider, 
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+        
         w.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        w.set_border_window_size(Gtk.TextWindowType.LEFT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.RIGHT, 4)
-        w.set_border_window_size(Gtk.TextWindowType.TOP, 4)
-        w.set_border_window_size(Gtk.TextWindowType.BOTTOM, 4)
+        w.set_left_margin(4)
+        w.set_right_margin(4)
+        w.set_top_margin(4)
+        w.set_bottom_margin(4)
         w.connect('realize', _textview_realize_cb)
         buf = w.get_buffer()
 
-        # TODO Fix for old Sugar 0.82 builds, red_float not available
-        bright = (
-            Gdk.color_parse(self.color.get_fill_color()).red_float +
-            Gdk.color_parse(self.color.get_fill_color()).green_float +
-            Gdk.color_parse(self.color.get_fill_color()).blue_float) / 3.0
+        # Parse color for brightness check
+        try:
+            fill_rgba = Gdk.RGBA()
+            fill_rgba.parse(fill_color)
+            bright = (fill_rgba.red + fill_rgba.green + fill_rgba.blue) / 3.0
+        except:
+            bright = 0.5
+        
         if bright < 0.5:
-            col = Gdk.color_parse('white')
+            col = 'white'
         else:
-            col = Gdk.color_parse('black')
+            col = 'black'
 
         tag = buf.create_tag(font=CalcLayout.FONT_SMALL_NARROW,
                              foreground=col)
@@ -821,24 +870,24 @@ class Calculate(ShareableActivity):
         self.text_copy()
         self.remove_character(1)
 
-    def keypress_cb(self, widget, event):
+    def keypress_cb(self, controller, keyval, keycode, state):
         if not self.text_entry.is_focus():
             return
 
-        key = Gdk.keyval_name(event.keyval)
-        if event.hardware_keycode == 219:
-            if (event.get_state() & Gdk.ModifierType.SHIFT_MASK):
+        key = Gdk.keyval_name(keyval)
+        if keycode == 219:
+            if (state & Gdk.ModifierType.SHIFT_MASK):
                 key = 'divide'
             else:
                 key = 'multiply'
         _logger.debug('Key: %s (%r, %r)', key,
-                      event.keyval, event.hardware_keycode)
+                      keyval, keycode)
 
-        if event.get_state() & Gdk.ModifierType.CONTROL_MASK:
+        if state & Gdk.ModifierType.CONTROL_MASK:
             if key in self.CTRL_KEYMAP:
                 f = self.CTRL_KEYMAP[key]
                 return f(self)
-        elif (event.get_state() & Gdk.ModifierType.SHIFT_MASK) and \
+        elif (state & Gdk.ModifierType.SHIFT_MASK) and \
                 key in self.SHIFT_KEYMAP:
             f = self.SHIFT_KEYMAP[key]
             return f(self)
@@ -973,7 +1022,7 @@ class Calculate(ShareableActivity):
 
 
 def main():
-    win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+    win = Gtk.Window()
     Calculate(win)
     Gtk.main()
     return 0

--- a/layout.py
+++ b/layout.py
@@ -20,13 +20,13 @@
 
 from gettext import gettext as _
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Pango
-import sugar3.profile
-from sugar3.graphics.style import FONT_SIZE
-from sugar3.graphics.combobox import ComboBox
+import sugar4.profile
+from sugar4.graphics.style import FONT_SIZE
+from sugar4.graphics.combobox import ComboBox
 from toolbars import EditToolbar
 from toolbars import AlgebraToolbar
 from toolbars import TrigonometryToolbar
@@ -36,9 +36,9 @@ from toolbars import MiscToolbar
 from numerals import local as _n
 
 try:
-    from sugar3.graphics.toolbarbox import ToolbarButton, ToolbarBox
-    from sugar3.activity.widgets import ActivityToolbarButton
-    from sugar3.activity.widgets import StopButton
+    from sugar4.graphics.toolbarbox import ToolbarButton, ToolbarBox
+    from sugar4.activity.widgets import ActivityToolbarButton
+    from sugar4.activity.widgets import StopButton
 except ImportError:
     pass
 
@@ -67,12 +67,12 @@ class CalcLayout:
         self.create_dialog()
 
     def create_color(self, rf, gf, bf):
-        return Gdk.Color.from_floats(rf, gf, bf)
+        return Gdk.RGBA(red=rf, green=gf, blue=bf, alpha=1.0)
 
     def create_button_data(self):
         """Create a list with button information. We need to do that here
         because we want to include the lambda functions."""
-
+        
         mul_sym = self._parent.ml.mul_sym
         div_sym = self._parent.ml.div_sym
         equ_sym = self._parent.ml.equ_sym
@@ -138,46 +138,60 @@ class CalcLayout:
 
 # Toolbar
         self._toolbar_box = ToolbarBox()
-        activity_button = ActivityToolbarButton(self._parent)
-        self._toolbar_box.toolbar.insert(activity_button, 0)
+        self._toolbar_box.set_orientation(Gtk.Orientation.VERTICAL)
+        self._toolbar_box.set_hexpand(True)
+        self._toolbar_box.set_vexpand(False)
 
-        def append(icon_name, label, page, position):
+        if hasattr(self._toolbar_box, "get_toolbar"):
+            self._toolbar = self._toolbar_box.get_toolbar()
+        else:
+            self._toolbar = self._toolbar_box.toolbar
+        if hasattr(self._toolbar, "set_orientation"):
+            self._toolbar.set_orientation(Gtk.Orientation.HORIZONTAL)
+        
+        activity_button = ActivityToolbarButton(self._parent)
+        activity_button.set_hexpand(False)
+        self._toolbar.append(activity_button)
+
+        def append(icon_name, label, page):
             toolbar_button = ToolbarButton()
-            toolbar_button.props.page = page
-            toolbar_button.props.icon_name = icon_name
-            toolbar_button.props.label = label
-            self._toolbar_box.toolbar.insert(toolbar_button, position)
+            if hasattr(toolbar_button, "set_page"):
+                toolbar_button.set_page(page)
+            else:
+                toolbar_button.props.page = page
+            if hasattr(toolbar_button, "set_icon_name"):
+                toolbar_button.set_icon_name(icon_name)
+            else:
+                toolbar_button.props.icon_name = icon_name
+            toolbar_button.set_tooltip(label)
+            toolbar_button.set_hexpand(False)
+            self._toolbar.append(toolbar_button)
         append('toolbar-edit',
                _('Edit'),
-               EditToolbar(self._parent),
-               -1)
+               EditToolbar(self._parent))
         append('toolbar-algebra',
                _('Algebra'),
-               AlgebraToolbar(self._parent),
-               -1)
+               AlgebraToolbar(self._parent))
         append('toolbar-trigonometry',
                _('Trigonometry'),
-               TrigonometryToolbar(self._parent),
-               -1)
+               TrigonometryToolbar(self._parent))
         append('toolbar-boolean',
                _('Boolean'),
-               BooleanToolbar(self._parent),
-               -1)
+               BooleanToolbar(self._parent))
         self._misc_toolbar = MiscToolbar(
             self._parent,
-            target_toolbar=self._toolbar_box.toolbar)
+            target_toolbar=self._toolbar)
         append('toolbar-constants',
                _('Miscellaneous'),
-               self._misc_toolbar,
-               5)
-        self._stop_separator = Gtk.SeparatorToolItem()
-        self._stop_separator.props.draw = False
-        self._stop_separator.set_expand(True)
+               self._misc_toolbar)
+        self._stop_separator = Gtk.Separator()
+        self._stop_separator.set_hexpand(True)
         self._stop_separator.show()
-        self._toolbar_box.toolbar.insert(self._stop_separator, -1)
+        self._toolbar.append(self._stop_separator)
         self._stop = StopButton(self._parent)
-        self._toolbar_box.toolbar.insert(self._stop, -1)
-        self._toolbar_box.show_all()
+        self._stop.set_hexpand(False)
+        self._toolbar.append(self._stop)
+        self._toolbar_box.show()
         self._parent.set_toolbar_box(self._toolbar_box)
 
 # Some layout constants
@@ -195,65 +209,80 @@ class CalcLayout:
 # Big - Table, 16 rows, 10 columns, homogeneously divided
         self.grid = Gtk.Grid()
         self.grid.set_column_homogeneous(True)
+        self.grid.set_row_homogeneous(False)  # Allow different row heights
         self.grid.set_row_spacing(0)
         self.grid.set_column_spacing(4)
+        self.grid.set_hexpand(True)
+        self.grid.set_vexpand(True)
 
 # Left part: container and input
         vc1 = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        vc1.set_vexpand(False)
+        vc1.set_valign(Gtk.Align.START)
         hc1 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
-        eb = Gtk.EventBox()
-        eb.add(hc1)
-        eb.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        eb.set_border_width(12)
-        eb2 = Gtk.EventBox()
-        eb2.add(eb)
-        eb2.modify_bg(Gtk.StateType.NORMAL, self.col_black)
+        hc1.set_margin_start(6)
+        hc1.set_margin_end(6)
+        hc1.set_margin_top(3)
+        hc1.set_margin_bottom(3)
+        
         label1 = Gtk.Label(label=_('Label:'))
-        label1.modify_fg(Gtk.StateType.NORMAL, self.col_white)
-        label1.set_alignment(1, 0.5)
-        hc1.pack_start(label1, expand=False, fill=False, padding=10)
+        label1.set_halign(Gtk.Align.END)
+        label1.set_valign(Gtk.Align.CENTER)
+        label1.set_margin_start(5)
+        label1.set_margin_end(5)
+        hc1.append(label1)
+        
         self.label_entry = Gtk.Entry()
-        self.label_entry.modify_bg(Gtk.StateType.INSENSITIVE, self.col_black)
-        hc1.pack_start(self.label_entry, expand=True, fill=True, padding=0)
-        vc1.pack_start(eb2, False, True, 0)
+        self.label_entry.set_hexpand(True)
+        hc1.append(self.label_entry)
+        vc1.append(hc1)
 
         self.text_entry = Gtk.Entry()
         try:
             self.text_entry.props.im_module = 'gtk-im-context-simple'
         except AttributeError:
             pass
-        self.text_entry.set_size_request(-1, 75)
-        self.text_entry.connect('key_press_event', self._parent.ignore_key_cb)
-        self.text_entry.modify_font(self.input_font)
-        self.text_entry.modify_bg(Gtk.StateType.INSENSITIVE, self.col_black)
-        eb = Gtk.EventBox()
-        eb.add(self.text_entry)
-        eb.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        eb.set_border_width(12)
-        eb2 = Gtk.EventBox()
-        eb2.add(eb)
-        eb2.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        vc1.pack_start(eb2, expand=True, fill=True, padding=0)
+        self.text_entry.set_size_request(-1, 60)
+        
+        controller = Gtk.EventControllerKey()
+        controller.connect('key-pressed', self._parent.ignore_key_cb)
+        self.text_entry.add_controller(controller)
+        
+        text_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        text_box.set_margin_start(6)
+        text_box.set_margin_end(6)
+        text_box.set_margin_top(3)
+        text_box.set_margin_bottom(3)
+        text_box.set_hexpand(True)
+        text_box.append(self.text_entry)
+        
+        vc1.append(text_box)
         self.grid.attach(vc1, 0, 0, 7, 6)
 
 # Left part: buttons
         self.pad = Gtk.Grid()
         self.pad.set_column_homogeneous(True)
+        self.pad.set_row_homogeneous(False)  # Don't force equal row heights
         self.pad.set_row_spacing(6)
         self.pad.set_column_spacing(6)
+        self.pad.set_vexpand(True)
+        self.pad.set_hexpand(True)
         self.create_button_data()
         self.buttons = {}
         for x, y, w, h, cap, bgcol, cb in self.button_data:
             button = self.create_button(
                 _(cap), cb, self.col_white, bgcol, w, h)
             button.set_vexpand(True)
+            button.set_hexpand(True)
             self.buttons[cap] = button
             self.pad.attach(button, x, y, w, h)
+            button.show()  # Explicitly show each button
 
-        eb = Gtk.EventBox()
-        eb.add(self.pad)
-        eb.modify_bg(Gtk.StateType.NORMAL, self.col_black)
-        self.grid.attach(eb, 0, 6, 7, 20)
+        pad_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        pad_box.set_vexpand(True)
+        pad_box.set_hexpand(True)
+        pad_box.append(self.pad)
+        self.grid.attach(pad_box, 0, 6, 7, 20)
 
 # Right part: container and equation button
         hc2 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
@@ -263,8 +292,12 @@ class CalcLayout:
         combo.append_item(2, _('Show variables'))
         combo.set_active(0)
         combo.connect('changed', self._history_filter_cb)
-        hc2.pack_start(combo, True, True, 0)
-        hc2.set_border_width(6)
+        combo.set_hexpand(True)
+        hc2.append(combo)
+        hc2.set_margin_start(6)
+        hc2.set_margin_end(6)
+        hc2.set_margin_top(6)
+        hc2.set_margin_bottom(6)
         self.grid.attach(hc2, 7, 0, 4, 2)
 
 # Right part: last equation
@@ -272,25 +305,13 @@ class CalcLayout:
         self.last_eq.set_editable(False)
         self.last_eq.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         self.last_eq.connect('realize', self._textview_realize_cb)
-        self.last_eq.modify_base(Gtk.StateType.NORMAL, Gdk.color_parse(
-                                 sugar3.profile.get_color().get_fill_color()))
-        self.last_eq.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse(
-                               sugar3.profile.get_color().get_stroke_color()))
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.LEFT, 4)
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.RIGHT, 4)
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.TOP, 4)
-        self.last_eq.set_border_window_size(Gtk.TextWindowType.BOTTOM, 4)
-
-        xo_color = sugar3.profile.get_color()
-        bright = (
-            Gdk.color_parse(xo_color.get_fill_color()).red_float +
-            Gdk.color_parse(xo_color.get_fill_color()).green_float +
-            Gdk.color_parse(xo_color.get_fill_color()).blue_float) / 3.0
-        if bright < 0.5:
-            self.last_eq.modify_text(Gtk.StateType.NORMAL, self.col_white)
-        else:
-            self.last_eq.modify_text(Gtk.StateType.NORMAL, self.col_black)
-
+        
+        # Set margins instead of border window size
+        self.last_eq.set_top_margin(4)
+        self.last_eq.set_bottom_margin(4)
+        self.last_eq.set_left_margin(4)
+        self.last_eq.set_right_margin(4)
+        
         self.grid.attach(self.last_eq, 7, 2, 4, 5)
 
 # Right part: history
@@ -301,34 +322,60 @@ class CalcLayout:
         self.history_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
                                     spacing=4)
         self.history_vbox.set_homogeneous(False)
-        self.history_vbox.set_border_width(0)
 
         self.variable_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
                                      spacing=4)
         self.variable_vbox.set_homogeneous(False)
-        self.variable_vbox.set_border_width(0)
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        vbox.pack_start(self.history_vbox, True, True, 0)
-        vbox.pack_start(self.variable_vbox, True, True, 0)
-        scrolled_window.add_with_viewport(vbox)
+        self.history_vbox.set_vexpand(True)
+        self.variable_vbox.set_vexpand(True)
+        vbox.append(self.history_vbox)
+        vbox.append(self.variable_vbox)
+        scrolled_window.set_child(vbox)
         self.grid.attach(scrolled_window, 7, 7, 4, 19)
 
-        Gdk.Screen.get_default().connect('size-changed',
-                                         self._configure_cb)
+        # Note: In GTK4, we could use surface state-changed events, 
+        # but for simplicity we skip dynamic reconfiguration for now
+        # The layout will be set on initial creation
 
     def _configure_cb(self, event):
         # Maybe redo layout
-        self._toolbar_box.toolbar.remove(self._stop)
-        self._toolbar_box.toolbar.remove(self._stop_separator)
+        self._toolbar.remove(self._stop)
+        self._toolbar.remove(self._stop_separator)
         self._misc_toolbar.update_layout()
-        self._toolbar_box.toolbar.insert(self._stop_separator, -1)
-        self._toolbar_box.toolbar.insert(self._stop, -1)
+        self._toolbar.append(self._stop_separator)
+        self._toolbar.append(self._stop)
 
     def show_it(self):
         """Show the dialog."""
         self._parent.set_canvas(self.grid)
-        self._parent.show_all()
+        
+        # In GTK4, we need to explicitly show widgets
+        # Show toolbar
+        self._toolbar_box.show()
+        
+        # Show all buttons in the calculator pad
+        for button in self.buttons.values():
+            button.show()
+        
+        # Show the pad grid itself
+        self.pad.show()
+        
+        # Show input widgets
+        self.label_entry.show()
+        self.text_entry.show()
+        
+        # Show last equation TextView
+        self.last_eq.show()
+        
+        # Show history/variable vboxes
+        self.history_vbox.show()
+        self.variable_vbox.show()
+        
+        # Show the main grid
+        self.grid.show()
+        
         self.show_history()
         self.text_entry.grab_focus()
 
@@ -349,13 +396,14 @@ class CalcLayout:
             self.toggle_select_graph(self.graph_selected)
 
         if not self.graph_selected:
-            widget.set_visible_window(True)
-            widget.set_above_child(True)
             self.graph_selected = widget
-            white = Gdk.color_parse('white')
-            widget.modify_bg(Gtk.StateType.NORMAL, white)
+            # Use CSS for styling in GTK4
+            css_provider = Gtk.CssProvider()
+            css = "box { background-color: white; }"
+            css_provider.load_from_data(css.encode())
+            widget.get_style_context().add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         else:
-            widget.set_visible_window(False)
+            # Remove CSS styling
             self.graph_selected = False
 
     def add_equation(self, textview, own, prepend=False):
@@ -363,31 +411,31 @@ class CalcLayout:
 
         GraphEventBox = None
         if isinstance(textview, Gtk.Image):
-            # Add the image inside the eventBox
-            GraphEventBox = Gtk.EventBox()
-            GraphEventBox.add(textview)
-            GraphEventBox.set_visible_window(False)
-            GraphEventBox.connect(
-                'button_press_event', self.toggle_select_graph)
+            # Use a regular Box instead of EventBox for GTK4
+            GraphEventBox = Gtk.Box()
+            GraphEventBox.append(textview)
+            
+            # Add gesture click controller for button press events
+            gesture = Gtk.GestureClick()
+            gesture.connect('pressed', lambda g, n, x, y: self.toggle_select_graph(GraphEventBox))
+            GraphEventBox.add_controller(gesture)
             GraphEventBox.show()
 
         if prepend:
             if GraphEventBox:
-                self.history_vbox.pack_start(GraphEventBox, False, True, 0)
-                self.history_vbox.reorder_child(GraphEventBox, 0)
+                self.history_vbox.prepend(GraphEventBox)
             else:
-                self.history_vbox.pack_start(textview, False, True, 0)
-                self.history_vbox.reorder_child(textview, 0)
+                self.history_vbox.prepend(textview)
         else:
             if GraphEventBox:
-                self.history_vbox.pack_end(GraphEventBox, False, True)
+                self.history_vbox.append(GraphEventBox)
             else:
-                self.history_vbox.pack_end(textview, False, True)
+                self.history_vbox.append(textview)
 
         if own:
             if GraphEventBox:
                 self._own_equations.append(GraphEventBox)
-                GraphEventBox.get_child().show()
+                GraphEventBox.get_first_child().show()
             else:
                 self._own_equations.append(textview)
                 textview.show()
@@ -395,7 +443,7 @@ class CalcLayout:
             if self._showing_all_history:
                 if GraphEventBox:
                     self._other_equations.append(GraphEventBox)
-                    GraphEventBox.get_child().show()
+                    GraphEventBox.get_first_child().show()
                 else:
                     self._other_equations.append(textview)
                     textview.show()
@@ -404,8 +452,8 @@ class CalcLayout:
         """Show both owned and other equations."""
         self._showing_all_history = True
         for key in self._other_equations:
-            if isinstance(key, Gtk.EventBox):
-                key.get_child().show()
+            if isinstance(key, Gtk.Box) and key.get_first_child():
+                key.get_first_child().show()
             else:
                 key.show()
 
@@ -413,8 +461,8 @@ class CalcLayout:
         """Show only owned equations."""
         self._showing_all_history = False
         for key in self._other_equations:
-            if isinstance(key, Gtk.EventBox):
-                key.get_child().hide()
+            if isinstance(key, Gtk.Box) and key.get_first_child():
+                key.get_first_child().hide()
             else:
                 key.hide()
 
@@ -426,13 +474,14 @@ class CalcLayout:
             del self._var_textviews[varname]
 
         self._var_textviews[varname] = textview
-        self.variable_vbox.pack_start(textview, False, True, 0)
+        self.variable_vbox.append(textview)
 
         # Reorder textviews for a sorted list
         names = list(self._var_textviews.keys())
         names.sort()
         for i in range(len(names)):
-            self.variable_vbox.reorder_child(self._var_textviews[names[i]], i)
+            self.variable_vbox.reorder_child_after(self._var_textviews[names[i]], 
+                                                   self._var_textviews[names[i-1]] if i > 0 else None)
 
         textview.show()
 
@@ -444,20 +493,19 @@ class CalcLayout:
 
     def create_button(self, cap, cb, fgcol, bgcol, width, height):
         """Create a button that is set up properly."""
-        button = Gtk.Button(_(cap))
+        button = Gtk.Button(label=_(cap))
         self.modify_button_appearance(button, fgcol, bgcol, width, height)
         button.connect("clicked", cb)
-        button.connect("key_press_event", self._parent.ignore_key_cb)
+        controller = Gtk.EventControllerKey()
+        controller.connect('key-pressed', self._parent.ignore_key_cb)
+        button.add_controller(controller)
         return button
 
     def modify_button_appearance(self, button, fgcol, bgcol, width, height):
         """Modify button style."""
         width = 50 * width
         button.get_child().set_size_request(width, height)
-        button.get_child().modify_font(self.button_font)
-        button.get_child().modify_fg(Gtk.StateType.NORMAL, fgcol)
-        button.modify_bg(Gtk.StateType.NORMAL, bgcol)
-        button.modify_bg(Gtk.StateType.PRELIGHT, bgcol)
+        # Keep default GTK styling
 
     def _history_filter_cb(self, combo):
         selection = combo.get_active()
@@ -472,6 +520,5 @@ class CalcLayout:
 
     def _textview_realize_cb(self, widget):
         '''Change textview properties once window is created.'''
-        win = widget.get_window(Gtk.TextWindowType.TEXT)
-        win.set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
+        widget.set_cursor(Gdk.Cursor.new_from_name('pointer', None))
         return False

--- a/main.py
+++ b/main.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk, GLib
+
+# ---- Setup Sugar environment ----
+os.environ.setdefault("SUGAR_BUNDLE_ID", "org.sugarlabs.Calculate")
+os.environ.setdefault("SUGAR_BUNDLE_NAME", "Calculate")
+os.environ.setdefault("SUGAR_BUNDLE_PATH", os.getcwd())
+os.environ.setdefault("SUGAR_ACTIVITY_ROOT", os.path.join(os.path.expanduser("~"), ".sugar", "default", "org.sugarlabs.Calculate"))
+
+# Create activity directories if they don't exist
+activity_root = os.environ["SUGAR_ACTIVITY_ROOT"]
+for subdir in ["tmp", "instance", "data"]:
+    path = os.path.join(activity_root, subdir)
+    os.makedirs(path, exist_ok=True)
+
+
+from sugar4.activity.activityhandle import ActivityHandle
+from calculate import Calculate
+
+
+def main(argv=None):
+    argv = argv or sys.argv
+    
+    # Keep reference to activity to prevent garbage collection
+    activity_ref = None
+
+    def on_activate(app):
+        nonlocal activity_ref
+        
+        # Create ActivityHandle for local run
+        handle = ActivityHandle(
+            activity_id="calculate-local",
+            object_id="calculate-local"
+        )
+
+        try:
+            # Create activity (Activity creates its own window)
+            activity_ref = Calculate(handle)
+            
+            # Add the activity window to the application
+            app.add_window(activity_ref)
+            
+            # Show the window
+            activity_ref.show()
+            
+            # Present the window (GTK4)
+            activity_ref.present()
+            
+        except Exception as e:
+            print(f"Error creating activity: {e}", file=sys.stderr)
+            import traceback
+            traceback.print_exc()
+            app.quit()
+
+    app = Gtk.Application(application_id="org.sugarlabs.Calculate.local")
+    app.connect("activate", on_activate)
+    
+    # Keep application running until window is closed
+    return app.run(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
-from sugar3.activity import bundlebuilder
+from sugar4.activity import bundlebuilder
 bundlebuilder.start()

--- a/shareable_activity.py
+++ b/shareable_activity.py
@@ -1,13 +1,14 @@
 import gi
 
 import dbus
+import dbus.service
 gi.require_version('TelepathyGLib', '0.12')
 from gi.repository import GObject
 from gi.repository import TelepathyGLib
 
-from sugar3.activity import activity
-from sugar3.presence import presenceservice
-from sugar3.presence.sugartubeconn import SugarTubeConnection
+from sugar4.activity.activity import Activity
+from sugar4.presence import presenceservice
+from sugar4.presence.sugartubeconn import SugarTubeConnection
 
 import logging
 _logger = logging.getLogger('ShareableActivity')
@@ -29,7 +30,7 @@ class ShareableObject(dbus.service.Object):
         pass
 
 
-class ShareableActivity(activity.Activity):
+class ShareableActivity(Activity):
 
     '''
     A shareable activity.
@@ -47,7 +48,7 @@ class ShareableActivity(activity.Activity):
             service_path
         '''
 
-        activity.Activity.__init__(self, handle, *args, **kwargs)
+        Activity.__init__(self, handle, *args, **kwargs,application=None)
 
         self._sync_hid = None
         self._message_cbs = {}

--- a/toolbars.py
+++ b/toolbars.py
@@ -2,16 +2,16 @@
 # toolbars.py, see CalcActivity.py for info
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
 from mathlib import MathLib
 
-from sugar3.graphics.palette import Palette
-from sugar3.graphics.menuitem import MenuItem
-from sugar3.graphics.toolbutton import ToolButton
-from sugar3.graphics.toggletoolbutton import ToggleToolButton
-from sugar3.graphics.style import GRID_CELL_SIZE
+from sugar4.graphics.palette import Palette
+from sugar4.graphics.menuitem import MenuItem
+from sugar4.graphics.toolbutton import ToolButton
+from sugar4.graphics.toggletoolbutton import ToggleToolButton
+from sugar4.graphics.style import GRID_CELL_SIZE
 
 import logging
 _logger = logging.getLogger('calc-activity')
@@ -23,9 +23,8 @@ def _icon_exists(name):
     if name == '':
         return False
 
-    theme = Gtk.IconTheme.get_default()
-    info = theme.lookup_icon(name, 0, 0)
-    if info:
+    theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+    if theme.has_icon(name):
         return True
 
     return False
@@ -94,10 +93,10 @@ class IconToggleToolButton(ToggleToolButton):
                 self.callback(but)
 
 
-class TextToggleToolButton(Gtk.ToggleToolButton):
+class TextToggleToolButton(Gtk.ToggleButton):
 
     def __init__(self, items, cb, desc, index=False):
-        Gtk.ToggleToolButton.__init__(self)
+        Gtk.ToggleButton.__init__(self)
         self.items = items
         self.set_label(items[0])
         self.selected = 0
@@ -117,23 +116,23 @@ class TextToggleToolButton(Gtk.ToggleToolButton):
                 self.callback(but)
 
 
-class LineSeparator(Gtk.SeparatorToolItem):
+class LineSeparator(Gtk.Separator):
 
     def __init__(self):
-        Gtk.SeparatorToolItem.__init__(self)
-        self.set_draw(True)
+        Gtk.Separator.__init__(self)
+        # set_draw() is removed in GTK4, separators are always drawn
 
 
-class EditToolbar(Gtk.Toolbar):
+class EditToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self)
 
         copy_tool = ToolButton('edit-copy')
         copy_tool.set_tooltip(_('Copy'))
         copy_tool.set_accelerator(_('<ctrl>c'))
         copy_tool.connect('clicked', lambda x: calc.text_copy())
-        self.insert(copy_tool, -1)
+        self.append(copy_tool)
 
         menu_item = MenuItem(_('Cut'))
 
@@ -146,186 +145,186 @@ class EditToolbar(Gtk.Toolbar):
         menu_item.show()
         copy_tool.get_palette().menu.append(menu_item)
 
-        self.insert(IconToolButton('edit-paste', _('Paste'),
+        self.append(IconToolButton('edit-paste', _('Paste'),
                                    lambda x: calc.text_paste(),
-                                   alt_html='Paste'), -1)
+                                   alt_html='Paste'))
 
-        self.show_all()
+        self.show()
 
 
-class AlgebraToolbar(Gtk.Toolbar):
+class AlgebraToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self)
 
-        self.insert(IconToolButton('algebra-square', _('Square'),
+        self.append(IconToolButton('algebra-square', _('Square'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_OP_POST, '**2'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(square)'),
-                                   alt_html='x<sup>2</sup>'), -1)
+                                   alt_html='x<sup>2</sup>'))
 
-        self.insert(IconToolButton('algebra-sqrt', _('Square root'),
+        self.append(IconToolButton('algebra-sqrt', _('Square root'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'sqrt'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(sqrt)'),
-                                   alt_html='√x'), -1)
+                                   alt_html='√x'))
 
-        self.insert(IconToolButton('algebra-xinv', _('Inverse'),
+        self.append(IconToolButton('algebra-xinv', _('Inverse'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_OP_POST, '**-1'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(inv)'),
-                                   alt_html='x<sup>-1</sup>'), -1)
+                                   alt_html='x<sup>-1</sup>'))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton('algebra-exp', _('e to the power x'),
+        self.append(IconToolButton('algebra-exp', _('e to the power x'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'exp'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(exp)'),
-                                   alt_html='e<sup>x</sup>'), -1)
+                                   alt_html='e<sup>x</sup>'))
 
-        self.insert(IconToolButton('algebra-xpowy', _('x to the power y'),
+        self.append(IconToolButton('algebra-xpowy', _('x to the power y'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'pow'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'help(pow)'),
-                                   alt_html='x<sup>y</sup>'), -1)
+                                   alt_html='x<sup>y</sup>'))
 
-        self.insert(IconToolButton('algebra-ln', _('Natural logarithm'),
+        self.append(IconToolButton('algebra-ln', _('Natural logarithm'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_FUNCTION, 'ln'),
                                    lambda x: calc.button_pressed(
-                                       calc.TYPE_TEXT, 'help(ln)')), -1)
+                                       calc.TYPE_TEXT, 'help(ln)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'algebra-fac', _('Factorial'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'factorial'),
             lambda x: calc.button_pressed(calc.TYPE_TEXT,
-                                          'help(factorial)')), -1)
+                                          'help(factorial)')))
 
-        self.show_all()
+        self.show()
 
 
-class TrigonometryToolbar(Gtk.Toolbar):
+class TrigonometryToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self)
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-sin', _('Sine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'sin'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sin)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sin)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-cos', _('Cosine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'cos'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cos)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cos)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-tan', _('Tangent'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'tan'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tan)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tan)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-asin', _('Arc sine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'asin'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(asin)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(asin)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-acos', _('Arc cosine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'acos'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(acos)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(acos)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-atan', _('Arc tangent'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'atan'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(atan)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(atan)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-sinh', _('Hyperbolic sine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'sinh'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sinh)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(sinh)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-cosh', _('Hyperbolic cosine'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'cosh'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cosh)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(cosh)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'trigonometry-tanh', _('Hyperbolic tangent'),
             lambda x: calc.button_pressed(calc.TYPE_FUNCTION, 'tanh'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tanh)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(tanh)')))
 
-        self.show_all()
+        self.show()
 
 
-class BooleanToolbar(Gtk.Toolbar):
+class BooleanToolbar(Gtk.Box):
 
     def __init__(self, calc):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self)
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-and', _('Logical and'),
             lambda x: calc.button_pressed(calc.TYPE_OP_POST, '&'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(And)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(And)')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-or', _('Logical or'),
             lambda x: calc.button_pressed(calc.TYPE_OP_POST, '|'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(Or)')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(Or)')))
 
-#        self.insert(IconToolButton('boolean-xor', _('Logical xor'),
+#        self.append(IconToolButton('boolean-xor', _('Logical xor'),
 #            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '^'),
-#            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(xor)')), -1)
+#            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'help(xor)')))
 
-        self.insert(LineSeparator(), -1)
+        self.append(LineSeparator())
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-eq', _('Equals'),
-            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '==')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '==')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'boolean-neq', _('Not equals'),
-            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '!=')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_OP_POST, '!=')))
 
-        self.show_all()
+        self.show()
 
 
-class MiscToolbar(Gtk.Toolbar):
+class MiscToolbar(Gtk.Box):
 
     def __init__(self, calc, target_toolbar=None):
         self._target_toolbar = target_toolbar
 
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self)
 
-        self.insert(IconToolButton('constants-pi', _('Pi'),
+        self.append(IconToolButton('constants-pi', _('Pi'),
                                    lambda x: calc.button_pressed(
                                        calc.TYPE_TEXT, 'pi'),
-                                   alt_html='π'), -1)
+                                   alt_html='π'))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'constants-e', _('e'),
-            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'e')), -1)
+            lambda x: calc.button_pressed(calc.TYPE_TEXT, 'e')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'constants-eulersconstant', _('γ'),
             lambda x: calc.button_pressed(calc.TYPE_TEXT,
-                                          '0.577215664901533')), -1)
+                                          '0.577215664901533')))
 
-        self.insert(IconToolButton(
+        self.append(IconToolButton(
             'constants-goldenratio', _('φ'),
             lambda x: calc.button_pressed(calc.TYPE_TEXT,
-                                          '1.618033988749895')), -1)
+                                          '1.618033988749895')))
 
         self._line_separator1 = LineSeparator()
         self._line_separator2 = LineSeparator()
@@ -380,16 +379,11 @@ class MiscToolbar(Gtk.Toolbar):
 
         self.update_layout()
 
-        self.show_all()
+        self.show()
 
     def update_layout(self):
-        if Gdk.Screen.width() < 14 * GRID_CELL_SIZE or \
-                self._target_toolbar is None:
-            target_toolbar = self
-            if self._target_toolbar is not None:
-                self._remove_buttons(self._target_toolbar)
-        else:
-            target_toolbar = self._target_toolbar
+        # Add items to the target toolbar (main toolbar)
+        target_toolbar = self._target_toolbar if self._target_toolbar else self
 
         for item in [self._line_separator1, self._plot_button,
                      self._line_separator2, self._angle_button,
@@ -397,7 +391,7 @@ class MiscToolbar(Gtk.Toolbar):
                      self._base_button]:
             if item.get_parent():
                 item.get_parent().remove(item)
-            target_toolbar.insert(item, -1)
+            target_toolbar.append(item)
 
     def _remove_buttons(self, toolbar):
         for item in [self._plot_button, self._line_separator1,


### PR DESCRIPTION

# Port Calculate Activity to GTK4

This PR migrates the activity from **GTK3 → GTK4** and replaces deprecated GTK3 APIs with GTK4 equivalents.
The Terminal activity GTK4 port was used as a reference while making these changes to follow Sugar GTK4 
migration patterns.

## Key Replacements

* `gi.require_version("Gtk", "3.0")` → `"4.0"`
* `sugar3` → `sugar4`
* `connect("key_press_event", ...)` → `Gtk.EventControllerKey`
* `Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)` → `Gdk.Display.get_default().get_clipboard()`
* `modify_bg()` / `modify_base()` → CSS styling using `Gtk.CssProvider`
* `Gdk.Cursor.new()` → `Gdk.Cursor.new_from_name()`
* `set_border_window_size()` → margin properties (`set_left_margin()`, `set_right_margin()`, etc.)
* `add()` → `set_child()`
* `pack_start()` / `pack_end()` → `append()`
* Updated `Gtk.Box` child management:

  * `box.pack_start(widget, ...)` → `box.append(widget)`
  * Removed `expand`, `fill`, and `padding` arguments
* Replace `show_all()` to `show()`
* Replaced deprecated `Gdk.Screen` usage with `Gdk.Display`
* Added `set_default_size()` for proper window sizing in GTK4

---
## Visual Changes:
After porting testing without sugar:
<img width="1920" height="1051" alt="image" src="https://github.com/user-attachments/assets/31056ac2-3d0d-44f9-b9b0-62b60539b548" />